### PR TITLE
[DODSS-948] Fix auth login

### DIFF
--- a/src/config/routes.tsx
+++ b/src/config/routes.tsx
@@ -1,11 +1,10 @@
-import { Routes, Route, Navigate } from "react-router-dom";
+import { Routes, Route, Navigate, Outlet } from "react-router-dom";
 import * as Sentry from "@sentry/react";
 import Login from "../modules/Auth/Login";
 import LandingPage from "../modules/LandingPage";
 import SurveysHomePage from "../modules/SurveysHomePage";
 import NewSurveyConfig from "../modules/NewSurveyConfig";
 import ModuleSelection from "../modules/ModuleSelection";
-import { ComponentType, ReactNode } from "react";
 import { getCookie } from "../utils/helper";
 import ForgotPassword from "../modules/Auth/ForgotPassword";
 import ResetPassword from "../modules/Auth/ResetPassword";
@@ -26,9 +25,9 @@ const isAuthenticated = () => {
   return rememberToken !== "";
 };
 
-const requireAuth = (Component: ComponentType<any>): ReactNode => {
+const PrivateRoute = () => {
   const isAuthorized = isAuthenticated();
-  return isAuthorized ? <Component /> : <Navigate to="/login" replace />;
+  return isAuthorized ? <Outlet /> : <Navigate to="/login" replace />;
 };
 
 const AppRoutes = () => {
@@ -38,48 +37,49 @@ const AppRoutes = () => {
       <Route path="/login" element={<Login />} />
       <Route path="/reset-password" element={<ForgotPassword />} />
       <Route path="/reset-password/:id/:token" element={<ResetPassword />} />
-      <Route path="/surveys" element={requireAuth(SurveysHomePage)} />
-      <Route
-        path="/survey-configuration/:survey_uid?"
-        element={requireAuth(SurveyConfiguration)}
-      />
-
-      <Route
-        path="/new-survey-config/:survey_uid?"
-        element={requireAuth(NewSurveyConfig)}
-      />
-      <Route
-        path="/module-selection/:survey_uid?"
-        element={requireAuth(ModuleSelection)}
-      />
-      <Route
-        path="/survey-information/:survey_uid?"
-        element={requireAuth(SurveyCTOInfomation)}
-      />
-      <Route
-        path="/survey-information/survey-cto-information/:survey_uid?"
-        element={requireAuth(SurveyCTOInfomation)}
-      />
-      <Route
-        path="/survey-information/survey-cto-questions/:survey_uid?/:form_uid?"
-        element={requireAuth(SurveyCTOQuestions)}
-      />
-      <Route
-        path="/survey-information/field-supervisor-roles/:path?/:survey_uid?"
-        element={requireAuth(FieldSupervisorRoles)}
-      />
-      <Route
-        path="/survey-information/location/add/:survey_uid?"
-        element={requireAuth(SurveyLocationAdd)}
-      />
-      <Route
-        path="/survey-information/location/hierarchy/:survey_uid?"
-        element={requireAuth(SurveyLocationHierarchy)}
-      />
-      <Route
-        path="/survey-information/location/upload/:survey_uid?"
-        element={requireAuth(SurveyLocationUpload)}
-      />
+      <Route element={<PrivateRoute />}>
+        <Route path="/surveys" element={<SurveysHomePage />} />
+        <Route
+          path="/survey-configuration/:survey_uid?"
+          element={<SurveyConfiguration />}
+        />
+        <Route
+          path="/new-survey-config/:survey_uid?"
+          element={<NewSurveyConfig />}
+        />
+        <Route
+          path="/module-selection/:survey_uid?"
+          element={<ModuleSelection />}
+        />
+        <Route
+          path="/survey-information/:survey_uid?"
+          element={<SurveyCTOInfomation />}
+        />
+        <Route
+          path="/survey-information/survey-cto-information/:survey_uid?"
+          element={<SurveyCTOInfomation />}
+        />
+        <Route
+          path="/survey-information/survey-cto-questions/:survey_uid?/:form_uid?"
+          element={<SurveyCTOQuestions />}
+        />
+        <Route
+          path="/survey-information/field-supervisor-roles/:path?/:survey_uid?"
+          element={<FieldSupervisorRoles />}
+        />
+        <Route
+          path="/survey-information/location/add/:survey_uid?"
+          element={<SurveyLocationAdd />}
+        />
+        <Route
+          path="/survey-information/location/hierarchy/:survey_uid?"
+          element={<SurveyLocationHierarchy />}
+        />
+        <Route
+          path="/survey-information/location/upload/:survey_uid?"
+          element={<SurveyLocationUpload />}
+        />
+      </Route>
       <Route path="*" element={<NotFound />} />
     </SentryRoutes>
   );


### PR DESCRIPTION
## [DODSS-948] Fix auth login

## Ticket

Fixes: https://idinsight.atlassian.net/browse/DODSS-948

## Description, Motivation and Context

- What is the goal of the PR?
Currently, screen is stuck in URL loop after login. This PR is intended to break it so that after clicking on Login button. User should go to survey page.


- What are the changes to achieve that goal?
I am replace `requireAuth` function to `React` component so that whenever `navigate("/surveys")` is called, it should change to state.

Regular function (`requireAuth`) can't state change. State changes is only happened in React components.

## How Has This Been Tested?
Locally

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have written [good commit messages][1]

[1]: http://chris.beams.io/posts/git-commit/

[DODSS-948]: https://idinsight.atlassian.net/browse/DODSS-948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ