### PR TITLE
[SS-988] Reset location data on component unmounting

### DIFF
--- a/src/modules/SurveyInformation/SurveyLocationAdd/SurveyLocationAdd.tsx
+++ b/src/modules/SurveyInformation/SurveyLocationAdd/SurveyLocationAdd.tsx
@@ -9,7 +9,7 @@ import {
   postSurveyLocationGeoLevels,
 } from "../../../redux/surveyLocations/surveyLocationsActions";
 import {
-  addSurveyLocationGeoLevel,
+  resetSurveyLocations,
   setSurveyLocationGeoLevels,
 } from "../../../redux/surveyLocations/surveyLocationsSlice";
 import {
@@ -227,6 +227,10 @@ function SurveyLocationAdd() {
 
   useEffect(() => {
     fetchSurveyLocationGeoLevels();
+
+    return () => {
+      dispatch(resetSurveyLocations());
+    };
   }, [dispatch]);
 
   return (

--- a/src/modules/SurveyInformation/SurveyLocationHierarchy/SurveyLocationHierarchy.tsx
+++ b/src/modules/SurveyInformation/SurveyLocationHierarchy/SurveyLocationHierarchy.tsx
@@ -17,7 +17,6 @@ import {
 import SideMenu from "../SideMenu";
 import {
   DescriptionText,
-  SelectItem,
   SurveyLocationHierarchyFormWrapper,
 } from "./SurveyLocationHierarchy.styled";
 import { useEffect, useState } from "react";
@@ -28,14 +27,11 @@ import {
   postSurveyLocationGeoLevels,
 } from "../../../redux/surveyLocations/surveyLocationsActions";
 import { DynamicItemsForm, StyledFormItem } from "../SurveyInformation.styled";
-import { GeoLevel } from "../../../redux/surveyLocations/types";
-import { setSurveyLocationGeoLevels } from "../../../redux/surveyLocations/surveyLocationsSlice";
+import {
+  resetSurveyLocations,
+  setSurveyLocationGeoLevels,
+} from "../../../redux/surveyLocations/surveyLocationsSlice";
 import FullScreenLoader from "../../../components/Loaders/FullScreenLoader";
-
-interface ILocationHierarchySelect {
-  name: string;
-  value: string;
-}
 
 function SurveyLocationHierarchy() {
   const [form] = Form.useForm();
@@ -68,6 +64,10 @@ function SurveyLocationHierarchy() {
 
   useEffect(() => {
     fetchSurveyLocationGeoLevels();
+
+    return () => {
+      dispatch(resetSurveyLocations());
+    };
   }, [dispatch]);
 
   const renderHierarchyGeoLevelsField = () => {
@@ -129,7 +129,7 @@ function SurveyLocationHierarchy() {
                 };
 
                 if (geoLevel) {
-                  const { geo_level_uid, parent_geo_level_uid } = geoLevel;
+                  const { geo_level_uid } = geoLevel;
 
                   if (
                     value &&

--- a/src/modules/SurveyInformation/SurveyLocationUpload/SurveyLocationUpload.tsx
+++ b/src/modules/SurveyInformation/SurveyLocationUpload/SurveyLocationUpload.tsx
@@ -21,7 +21,7 @@ import {
   SelectItem,
   SurveyLocationUploadFormWrapper,
 } from "./SurveyLocationUpload.styled";
-import { CloudDownloadOutlined, LinkOutlined } from "@ant-design/icons";
+import { LinkOutlined } from "@ant-design/icons";
 import { useEffect, useState } from "react";
 import LocationTable from "./LocationTable";
 import FileUpload from "./FileUpload";
@@ -32,6 +32,7 @@ import {
   getSurveyLocations,
   postSurveyLocations,
 } from "../../../redux/surveyLocations/surveyLocationsActions";
+import { resetSurveyLocations } from "../../../redux/surveyLocations/surveyLocationsSlice";
 import FullScreenLoader from "../../../components/Loaders/FullScreenLoader";
 import { AddAnotherButton } from "../SurveyInformation.styled";
 import { GeoLevelMapping } from "../../../redux/surveyLocations/types";
@@ -97,12 +98,15 @@ function SurveyLocationUpload() {
     fetchSurveyLocations();
 
     fetchSurveyLocationGeoLevels();
-    console.log("surveyLocations", surveyLocations);
     if (surveyLocations?.records?.length > 0) {
       setHasError(false);
       setColumnMatch(true);
       setFileUploaded(true);
     }
+
+    return () => {
+      dispatch(resetSurveyLocations());
+    };
   }, [dispatch]);
 
   const handleFileUpload = (

--- a/src/redux/surveyLocations/surveyLocationsActions.ts
+++ b/src/redux/surveyLocations/surveyLocationsActions.ts
@@ -1,4 +1,4 @@
-import { compose, createAsyncThunk } from "@reduxjs/toolkit";
+import { createAsyncThunk } from "@reduxjs/toolkit";
 
 import * as api from "./apiService";
 import { GeoLevel, GeoLevelMapping } from "./types";

--- a/src/redux/surveyLocations/surveyLocationsSlice.ts
+++ b/src/redux/surveyLocations/surveyLocationsSlice.ts
@@ -87,6 +87,9 @@ const surveyLocationsSlice = createSlice({
       state.loading = false;
       state.error = action.payload;
     },
+    resetSurveyLocations: () => {
+      return initialState;
+    },
   },
 });
 
@@ -105,6 +108,7 @@ export const {
   postSurveyLocationsSuccess,
   setSurveyLocationGeoLevels,
   addSurveyLocationGeoLevel,
+  resetSurveyLocations,
 } = surveyLocationsSlice.actions;
 
 export default surveyLocationsSlice.reducer;


### PR DESCRIPTION
## [SS-988] Fix: Locations data getting copied in all surveys

## Ticket

Fixes: https://idinsight.atlassian.net/browse/SS-988

## Description, Motivation and Context

- What is the goal of the PR?
Currently, location data is being copied in all survey. Example: If user opens a survey then navigate to different survey. Then they are seeing old survey in new navigated survey. This PR is fixing this issue.


- What are the changes to achieve that goal?
`resetSurveyLocations` is being added to reset the Redux state. When user will navigate to different component then `useEffect` will be fire on unmounting event that will dispatch `resetSurveyLocations`.


## How Has This Been Tested?
Yes, locally.


## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have written [good commit messages][1]

[1]: http://chris.beams.io/posts/git-commit/

[SS-988]: https://idinsight.atlassian.net/browse/SS-988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ