### PR TITLE
[SS-1099] Make parent open if child item is selected in Sidebar

### DIFF
--- a/src/modules/SurveyInformation/SideMenu.tsx
+++ b/src/modules/SurveyInformation/SideMenu.tsx
@@ -21,7 +21,7 @@ import {
 } from "../../shared/SideMenu.styled";
 import { Menu, MenuProps } from "antd";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 function SideMenu() {
   const location = useLocation();
@@ -297,16 +297,34 @@ function SideMenu() {
     },
   ];
   const [current, setCurrent] = useState("mail");
+  const [openKeys, setOpenKeys] = useState<string[]>([]);
 
   const onClick: MenuProps["onClick"] = (e) => {
     setCurrent(e.key);
   };
+
+  const getPossibleKey = () => {
+    const path = location.pathname;
+    if (path.includes("field-supervisor-roles/"))
+      return "surveyFieldSupervisorRoles";
+    if (path.includes("location/")) return "surveyLocation";
+    if (path.includes("enumerators/")) return "surveyEnumerators";
+
+    return "";
+  };
+
+  useEffect(() => {
+    const key: string = getPossibleKey();
+    setOpenKeys([key]);
+  }, [setOpenKeys]);
 
   return (
     <SideMenuWrapper>
       <Menu
         onClick={onClick}
         selectedKeys={[current]}
+        openKeys={openKeys}
+        onOpenChange={(key) => setOpenKeys(key)}
         mode="inline"
         items={items}
       />


### PR DESCRIPTION
## [SS-1099] Make parent open if child item is selected in Sidebar

## Ticket

Fixes: https://idinsight.atlassian.net/browse/SS-1099

## Description, Motivation and Context
Fixing the sidebar to remain parent option opened if children is selected

## How Has This Been Tested?
Yes, Locally

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [ ] I have written [good commit messages][1]

[SS-1099]: https://idinsight.atlassian.net/browse/SS-1099?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ