### PR TITLE
[DDSSPB-9] Add deselect module logic on frontend

### DIFF
--- a/src/modules/ModuleSelection/ModuleSelectionForm.tsx
+++ b/src/modules/ModuleSelection/ModuleSelectionForm.tsx
@@ -88,6 +88,28 @@ const ModuleSelectionForm: FC<ModuleSelectionFormProps> = () => {
   const handleCheckboxChange = (cardId: string) => {
     setSelectedCards((prevSelectedCards: string[]) => {
       if (prevSelectedCards.includes(cardId)) {
+        // Check if deselected module status is "Not Started"
+        const deselecting_module = modulesStatus.filter((item) => {
+          return item.module_id === parseInt(cardId);
+        });
+        if (deselecting_module[0].config_status !== "Not Started") {
+          message.error(
+            'Only modules with "Not Started" status can be deselected.'
+          );
+          return [...prevSelectedCards];
+        }
+
+        // Check if all modules status is not "Done"
+        const overall_status = modulesStatus.every((item: any) => {
+          return item["config_status"] === "Done";
+        });
+        if (overall_status) {
+          message.error(
+            "Module can't be deselect as all module status has been done."
+          );
+          return [...prevSelectedCards];
+        }
+
         return prevSelectedCards.filter((id) => id !== cardId);
       } else {
         return [...prevSelectedCards, cardId];


### PR DESCRIPTION
## [DDSSPB-9] Add deselect module logic on frontend

## Ticket

Fixes: https://idinsight.atlassian.net/browse/DDSSPB-9

## Description, Motivation and Context
Adding logic to deselect the module on module selection screen. Backend PR is already merged.

## How Has This Been Tested?
Locally at http://localhost:3000/module-selection/22

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [ ] I have written [good commit messages][1]

[DDSSPB-9]: https://idinsight.atlassian.net/browse/DDSSPB-9?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ