### PR TITLE
[DDSSPB-49] Call onFileUpload after validation

### DIFF
--- a/src/modules/SurveyInformation/TargetsUpload/FileUpload.tsx
+++ b/src/modules/SurveyInformation/TargetsUpload/FileUpload.tsx
@@ -1,10 +1,7 @@
 import { Dispatch, SetStateAction, useState } from "react";
 import { CloseCircleOutlined, InboxOutlined } from "@ant-design/icons";
 import { Button, Upload, message } from "antd";
-import CSVFileValidator, {
-  FieldSchema,
-  ValidatorConfig,
-} from "csv-file-validator";
+import { FieldSchema } from "csv-file-validator";
 
 import { Buffer } from "buffer";
 import {
@@ -103,6 +100,24 @@ function FileUpload({
         return false;
       }
     }
+
+    reader.onload = () => {
+      const csvData = reader.result as string;
+      const encodedData = csvData.split(",")[1]; // Extract the base64 data
+      const decodedData = Buffer.from(encodedData, "base64").toString(); // Decode the base64 data
+      const rows = decodedData.split("\n");
+      const columnNames = rows[0]
+        .split(",")
+        .map((columnName) => columnName.trim()); // Trim the column names
+
+      setTimeout(() => {
+        onFileUpload(file, columnNames, rows, encodedData);
+        onSuccess("ok", new XMLHttpRequest());
+        message.success(`${file.name} file uploaded successfully.`);
+        setUploadStatus(true);
+      }, 1000);
+    };
+    reader.readAsDataURL(file); // Use the 'file' object directly
   };
 
   const handleDrop = (e: React.DragEvent) => {


### PR DESCRIPTION
## [DDSSPB-49] Call onFileUpload after validation

## Ticket

Fixes: https://idinsight.atlassian.net/browse/DDSSPB-49

## Description, Motivation and Context
PR #89 is removing the logic to send the data back to Target component from FileUpload component. So currently, if user is selecting the file then it is just getting validate but onFileUpload (src/modules/SurveyInformation/TargetsUpload/FileUpload.tsx) is never being call to pass the data back to Target component (src/modules/SurveyInformation/TargetsUpload/TargetsUpload.tsx).

## How Has This Been Tested?
Locally

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have written [good commit messages][1]

[DDSSPB-49]: https://idinsight.atlassian.net/browse/DDSSPB-49?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ