### PR TITLE
[DDSSPB-12] Disable re-editing of location and role

### DIFF
--- a/src/modules/SurveyInformation/FieldSupervisorRoles/FieldSupervisorRolesAdd.tsx
+++ b/src/modules/SurveyInformation/FieldSupervisorRoles/FieldSupervisorRolesAdd.tsx
@@ -41,6 +41,7 @@ function FieldSupervisorRolesAdd() {
   const [numRoleFields, setNumRoleFields] = useState(
     supervisorRoles.length !== 0 ? supervisorRoles.length : 1
   );
+  const [isAllowedEdit, setIsAllowEdit] = useState<boolean>(true);
 
   const [form] = Form.useForm();
   const navigate = useNavigate();
@@ -50,6 +51,7 @@ function FieldSupervisorRolesAdd() {
     const res = await dispatch(getSupervisorRoles({ survey_uid: survey_uid }));
     setNumRoleFields(res.payload.length === 0 ? 1 : res.payload.length);
     if (res.payload.length > 0) {
+      setIsAllowEdit(false);
       form.setFieldValue("role_0", res.payload[0].role_name);
     }
   };
@@ -109,7 +111,11 @@ function FieldSupervisorRolesAdd() {
             },
           ]}
         >
-          <Input placeholder="Enter role name" style={{ width: "100%" }} />
+          <Input
+            placeholder="Enter role name"
+            style={{ width: "100%" }}
+            disabled={!isAllowedEdit}
+          />
         </StyledFormItem>
       );
     });
@@ -231,6 +237,7 @@ function FieldSupervisorRolesAdd() {
                 onClick={handleAddRole}
                 type="dashed"
                 style={{ width: "100%" }}
+                disabled={!isAllowedEdit}
               >
                 <FileAddOutlined /> Add another role
               </AddAnotherButton>

--- a/src/modules/SurveyInformation/SurveyLocationAdd/SurveyLocationAdd.tsx
+++ b/src/modules/SurveyInformation/SurveyLocationAdd/SurveyLocationAdd.tsx
@@ -61,6 +61,9 @@ function SurveyLocationAdd() {
   const [numLocationFields, setNumLocationFields] = useState(
     surveyLocationGeoLevels.length !== 0 ? surveyLocationGeoLevels.length : 1
   );
+
+  const [isAllowedEdit, setIsAllowEdit] = useState<boolean>(true);
+
   const handleFormValuesChange = async () => {
     const formValues = form.getFieldsValue();
 
@@ -85,6 +88,7 @@ function SurveyLocationAdd() {
       );
       setNumLocationFields(res.payload.length === 0 ? 1 : res.payload.length);
       if (res.payload.length > 0) {
+        setIsAllowEdit(false);
         form.setFieldValue("geo_level_0", res.payload[0].geo_level_name);
       }
     }
@@ -130,7 +134,11 @@ function SurveyLocationAdd() {
             },
           ]}
         >
-          <Input placeholder="Enter location label" style={{ width: "100%" }} />
+          <Input
+            placeholder="Enter location label"
+            style={{ width: "100%" }}
+            disabled={!isAllowedEdit}
+          />
         </StyledFormItem>
       );
     });
@@ -267,6 +275,7 @@ function SurveyLocationAdd() {
                     onClick={handleAddGeoLevel}
                     type="dashed"
                     style={{ width: "100%" }}
+                    disabled={!isAllowedEdit}
                   >
                     <FileAddOutlined /> Add another location
                   </AddAnotherButton>


### PR DESCRIPTION
## [DDSSPB-12] Disable re-editing of location and role

## Ticket

Fixes: https://idinsight.atlassian.net/browse/DDSSPB-12

## Description, Motivation and Context
Currently, re-editing of location and roles can lead to data inconsistency. This PR disabling the addition and editing of location and roles if they exist already.

## How Has This Been Tested?
Locally at http://localhost:3000/survey-configuration/14

## UI Changes
<img width="1440" alt="Screenshot 2023-09-12 at 3 02 03 PM" src="https://github.com/IDinsight/surveystream_react_app/assets/19777712/d61ca902-8ff3-43b7-a496-6873805d01ec">

<img width="1440" alt="Screenshot 2023-09-12 at 3 08 17 PM" src="https://github.com/IDinsight/surveystream_react_app/assets/19777712/580f78a4-4a17-4694-a1f4-19335a487442">


## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have written [good commit messages][1]

[DDSSPB-12]: https://idinsight.atlassian.net/browse/DDSSPB-12?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ