### PR TITLE
[DDSSPB-53] Fix selecting and then deselecting a module

### DIFF
--- a/src/modules/ModuleSelection/ModuleSelectionForm.tsx
+++ b/src/modules/ModuleSelection/ModuleSelectionForm.tsx
@@ -88,26 +88,32 @@ const ModuleSelectionForm: FC<ModuleSelectionFormProps> = () => {
   const handleCheckboxChange = (cardId: string) => {
     setSelectedCards((prevSelectedCards: string[]) => {
       if (prevSelectedCards.includes(cardId)) {
-        // Check if deselected module status is "Not Started"
-        const deselecting_module = modulesStatus.filter((item) => {
-          return item.module_id === parseInt(cardId);
-        });
-        if (deselecting_module[0].config_status !== "Not Started") {
-          message.error(
-            'Only modules with "Not Started" status can be deselected.'
-          );
-          return [...prevSelectedCards];
-        }
+        if (modulesStatus.length > 0) {
+          // Check if deselected module status is "Not Started"
+          const deselecting_module = modulesStatus.filter((item) => {
+            return item.module_id === parseInt(cardId);
+          });
 
-        // Check if all modules status is not "Done"
-        const overall_status = modulesStatus.every((item: any) => {
-          return item["config_status"] === "Done";
-        });
-        if (overall_status) {
-          message.error(
-            "Module can't be deselect as all module status has been done."
-          );
-          return [...prevSelectedCards];
+          if (
+            deselecting_module.length > 0 &&
+            deselecting_module[0].config_status !== "Not Started"
+          ) {
+            message.error(
+              'Only modules with "Not Started" status can be deselected.'
+            );
+            return [...prevSelectedCards];
+          }
+
+          // Check if all modules status is not "Done"
+          const overall_status = modulesStatus.every((item: any) => {
+            return item["config_status"] === "Done";
+          });
+          if (overall_status) {
+            message.error(
+              "Module can't be deselect as all module status has been done."
+            );
+            return [...prevSelectedCards];
+          }
         }
 
         return prevSelectedCards.filter((id) => id !== cardId);


### PR DESCRIPTION
## [DDSSPB-53] Fix selecting and then deselecting a module

## Ticket

Fixes: https://idinsight.atlassian.net/jira/software/c/projects/DDSSPB/issues/DDSSPB-53

## Description, Motivation and Context
Currently, if user select and deselect the module. Page is going to blank because frontend trying to remove the module from Redux state which is initially empty.

## How Has This Been Tested?
Locally

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [ ] I have written [good commit messages][1]

[DDSSPB-53]: https://idinsight.atlassian.net/browse/DDSSPB-53?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ