### PR TITLE
Targets Merge Functionality Integration 

### DIFF
--- a/src/modules/SurveyInformation/Enumerators/EnumeratorsHome/EnumeratorsHome.tsx
+++ b/src/modules/SurveyInformation/Enumerators/EnumeratorsHome/EnumeratorsHome.tsx
@@ -254,7 +254,8 @@ function EnumeratorsHome() {
         for (const key in originalData[0]) {
           if (
             Object.prototype.hasOwnProperty.call(originalData[0], key) &&
-            key !== "custom_fields"
+            key !== "custom_fields" &&
+            !columnsToExclude.includes(key)
           ) {
             columnMapping[key] = key;
           }

--- a/src/modules/SurveyInformation/Enumerators/EnumeratorsReupload/EnumeratorsReupload.tsx
+++ b/src/modules/SurveyInformation/Enumerators/EnumeratorsReupload/EnumeratorsReupload.tsx
@@ -111,9 +111,9 @@ function EnumeratorsReupload({ setScreenMode }: IEnumeratorsReupload) {
         {enumeratorColumnMapping !== null &&
           Object.keys(enumeratorColumnMapping).length > 0 && (
             <ul>
-              {Object.keys(enumeratorColumnMapping).map((key) => (
-                <li key={key}>{key}</li>
-              ))}
+              {Object.keys(enumeratorColumnMapping).map(
+                (key) => key !== "custom_fields" && <li key={key}>{key}</li>
+              )}
             </ul>
           )}
       </DescriptionContainer>

--- a/src/modules/SurveyInformation/SurveyLocationAdd/SurveyLocationAdd.tsx
+++ b/src/modules/SurveyInformation/SurveyLocationAdd/SurveyLocationAdd.tsx
@@ -95,6 +95,7 @@ function SurveyLocationAdd() {
       }
     }
   };
+
   const renderLocationFields = () => {
     const fields = Array.from({ length: numLocationFields }, (_, index) => {
       const geoLevel: {

--- a/src/modules/SurveyInformation/Targets/TargetsHome/TargetsHome.tsx
+++ b/src/modules/SurveyInformation/Targets/TargetsHome/TargetsHome.tsx
@@ -17,7 +17,10 @@ import {
 import { useEffect, useState } from "react";
 import RowEditingModal from "./RowEditingModal";
 import TargetsCountBox from "../../../../components/TargetsCountBox";
-import { setLoading } from "../../../../redux/targets/targetSlice";
+import {
+  setLoading,
+  setTargetsColumnMapping,
+} from "../../../../redux/targets/targetSlice";
 import { useAppDispatch, useAppSelector } from "../../../../redux/hooks";
 import { RootState } from "../../../../redux/store";
 import { getSurveyCTOForm } from "../../../../redux/surveyCTOInformation/surveyCTOInformationActions";
@@ -26,6 +29,7 @@ import FullScreenLoader from "../../../../components/Loaders/FullScreenLoader";
 import { useCSVDownloader } from "react-papaparse";
 import TargetsReupload from "../TargetsReupload";
 import TargetsRemap from "../TargetsRemap";
+import { includes } from "cypress/types/lodash";
 
 function TargetsHome() {
   const navigate = useNavigate();
@@ -141,10 +145,6 @@ function TargetsHome() {
     setEditData(false);
   };
 
-  const moveToUpload = () => {
-    navigate(`/survey-information/targets/upload/${survey_uid}/${form_uid}`);
-  };
-
   const handleFormUID = async () => {
     if (form_uid == "" || form_uid == undefined || form_uid == "undefined") {
       try {
@@ -176,10 +176,47 @@ function TargetsHome() {
       setTargetsCount(originalData.length);
 
       if (originalData.length == 0) {
+        navigate(
+          `/survey-information/targets/upload/${survey_uid}/${form_uid}`
+        );
         return;
       }
 
-      const columnsToExclude = ["target_uid", "target_locations"];
+      const columnsToExclude = [
+        "target_uid",
+        "target_locations",
+        "completed_flag",
+        "last_attempt_survey_status",
+        "last_attempt_survey_status_label",
+        "num_attempts",
+        "refusal_flag",
+        "revisit_sections",
+        "target_assignable",
+        "webapp_tag_color",
+      ];
+      //set targets column mapping
+
+      if (originalData[0]?.custom_fields?.column_mapping) {
+        dispatch(
+          setTargetsColumnMapping(
+            originalData[0]?.custom_fields?.column_mapping
+          )
+        );
+      } else {
+        const columnMapping: any = {};
+
+        for (const key in originalData[0]) {
+          if (
+            Object.prototype.hasOwnProperty.call(originalData[0], key) &&
+            key !== "custom_fields" &&
+            !columnsToExclude.includes(key)
+          ) {
+            columnMapping[key] = key;
+          }
+        }
+
+        dispatch(setTargetsColumnMapping(columnMapping));
+      }
 
       // Define column mappings
       let columnMappings = Object.keys(originalData[0])
@@ -296,43 +333,6 @@ function TargetsHome() {
 
     fetchData();
   }, [form_uid]);
-
-  /*
-   * New design configs
-   */
-  const [screenMode, setScreenMode] = useState<string>("manage");
-  const [newTargetModal, setNewTargetModal] = useState<boolean>(false);
-
-  // Mode: overwrite or merge
-  const [newTargetMode, setNewTargetMode] = useState<string>("");
-
-  const [isTargetInUse, setIsTargetInUse] = useState<boolean>(false);
-
-  const handleNewTargetMode = () => {
-    // Emit error if no new targets mode is selected
-    if (newTargetMode === "") {
-      message.error("Please select the mode to add new targets.");
-      return;
-    }
-
-    // Redirect to upload fresh targets, in case of fresh upload, otherwise start append mode
-    if (newTargetMode === "overwrite") {
-      navigate(`/survey-information/targets/upload/${survey_uid}/${form_uid}`);
-      return;
-    } else if (newTargetMode === "merge") {
-      setScreenMode("reupload");
-    }
-
-    setNewTargetModal(false);
-  };
-
-  const handlerAddTargetBtn = () => {
-    if (tableDataSource.length > 0) {
-      setNewTargetModal(true);
-    } else {
-      navigate(`/survey-information/targets/upload/${survey_uid}/${form_uid}`);
-    }
-  };
 
   return (
     <>

--- a/src/modules/SurveyInformation/Targets/TargetsMap/TargetsMap.tsx
+++ b/src/modules/SurveyInformation/Targets/TargetsMap/TargetsMap.tsx
@@ -273,9 +273,7 @@ function TargetsMap() {
 
           setHasError(false);
           //route to manage
-          navigate(
-            `/survey-information/targets/manage/${survey_uid}/${form_uid}`
-          );
+          navigate(`/survey-information/targets/${survey_uid}/${form_uid}`);
         } else {
           message.error("Failed to upload kindly check and try again");
           setHasError(true);
@@ -404,6 +402,8 @@ function TargetsMap() {
       }
     }
 
+    console.log("lowestGeoLevel", lowestGeoLevel);
+
     return lowestGeoLevel;
   };
 
@@ -426,6 +426,8 @@ function TargetsMap() {
           );
 
           const locationData = locationRes?.payload;
+
+          console.log("locationData", locationData);
 
           const lowestGeoLevel = findLowestGeoLevel(locationData);
 

--- a/src/modules/SurveyInformation/Targets/TargetsReupload/TargetsReupload.tsx
+++ b/src/modules/SurveyInformation/Targets/TargetsReupload/TargetsReupload.tsx
@@ -1,4 +1,5 @@
 import { useNavigate, useParams } from "react-router-dom";
+import { RootState } from "../../../../redux/store";
 import { Button, Col, Form, Row, message } from "antd";
 import { Title } from "../../../../shared/Nav.styled";
 import {
@@ -11,7 +12,7 @@ import {
 import { CloseOutlined } from "@ant-design/icons";
 import FileUpload from "./FileUpload";
 import { Dispatch, SetStateAction, useEffect, useState } from "react";
-import { useAppDispatch } from "../../../../redux/hooks";
+import { useAppDispatch, useAppSelector } from "../../../../redux/hooks";
 import {
   setTargetsBase64Data,
   setTargetsCSVColumns,
@@ -33,6 +34,8 @@ interface ITargetsReupload {
 
 function TargetsReupload({ setScreenMode }: ITargetsReupload) {
   const navigate = useNavigate();
+  const dispatch = useAppDispatch();
+  const [form] = Form.useForm();
 
   const { survey_uid } = useParams<{ survey_uid: string }>() ?? {
     survey_uid: "",
@@ -41,14 +44,14 @@ function TargetsReupload({ setScreenMode }: ITargetsReupload) {
     form_uid: "",
   };
 
-  const [form] = Form.useForm();
-
   const [reupload, setReupload] = useState<boolean>(false);
   const [fileUploaded, setFileUploaded] = useState<boolean>(false);
   const [hasError, setHasError] = useState<boolean>(false);
   const [errorList, setErrorList] = useState<CSVError[]>([]);
 
-  const dispatch = useAppDispatch();
+  const targetsColumnMapping = useAppSelector(
+    (state: RootState) => state.targets.targetsColumnMapping
+  );
 
   const errorTableColumn = [
     {
@@ -74,11 +77,6 @@ function TargetsReupload({ setScreenMode }: ITargetsReupload) {
     rows: string[],
     base64Data: string
   ) => {
-    // Access the file upload results
-    console.log("File:", file);
-    console.log("Column Names:", columnNames);
-    console.log("rows:", rows);
-
     dispatch(setTargetsCSVColumns(columnNames));
     dispatch(setTargetsCSVRows(rows));
     dispatch(setTargetsFileUpload(true));
@@ -146,51 +144,16 @@ function TargetsReupload({ setScreenMode }: ITargetsReupload) {
             ]}
           />
           <DescriptionContainer>
-            The following columns are existing in the targets table currently.
-            The mandatory columns are indicated with a <Mandatory>*</Mandatory>:
-            <ol type="a">
-              <li>
-                Target ID <Mandatory>*</Mandatory>
-              </li>
-              <li>
-                Target Name <Mandatory>*</Mandatory>
-              </li>
-              <li>
-                Language <Mandatory>*</Mandatory>
-              </li>
-              <li>
-                Address <Mandatory>*</Mandatory>
-              </li>
-              <li>
-                Gender <Mandatory>*</Mandatory>
-              </li>
-              <li>
-                State <Mandatory>*</Mandatory>
-              </li>
-              <li>
-                District <Mandatory>*</Mandatory>
-              </li>
-              <li>
-                Block <Mandatory>*</Mandatory>
-              </li>
-              <li>
-                PSU <Mandatory>*</Mandatory>
-              </li>
-              <li>
-                State ID <Mandatory>*</Mandatory>
-              </li>
-              <li>
-                District ID <Mandatory>*</Mandatory>
-              </li>
-              <li>
-                Block ID <Mandatory>*</Mandatory>
-              </li>
-              <li>
-                PSU ID <Mandatory>*</Mandatory>
-              </li>
-              <li>Number of household members</li>
-              <li>Female head of household </li>
-            </ol>
+            The following columns are existing in the enumerators table
+            currently.
+            {targetsColumnMapping !== null &&
+              Object.keys(targetsColumnMapping).length > 0 && (
+                <ul>
+                  {Object.keys(targetsColumnMapping).map(
+                    (key) => key !== "custom_fields" && <li key={key}>{key}</li>
+                  )}
+                </ul>
+              )}
           </DescriptionContainer>
         </>
       ) : null}

--- a/src/redux/enumerators/enumeratorsSlice.ts
+++ b/src/redux/enumerators/enumeratorsSlice.ts
@@ -12,6 +12,7 @@ interface EnumeratorsState {
   enumeratorColumnMapping: any;
   mappingErrorStatus: boolean;
   mappingErrorList: any;
+  mappingErrorCount: number;
 }
 
 const initialState: EnumeratorsState = {
@@ -26,6 +27,7 @@ const initialState: EnumeratorsState = {
   enumeratorColumnMapping: null,
   mappingErrorStatus: false,
   mappingErrorList: null,
+  mappingErrorCount: 0,
 };
 
 const enumeratorsSlice = createSlice({
@@ -69,6 +71,9 @@ const enumeratorsSlice = createSlice({
     },
     setMappingErrorList: (state, action: PayloadAction<any>) => {
       state.mappingErrorList = action.payload;
+    },
+    setMappingErrorCount: (state, action: PayloadAction<any>) => {
+      state.mappingErrorCount = action.payload;
     },
 
     getEnumeratorsRequest: (state) => {
@@ -176,6 +181,7 @@ export const {
   setLoading,
   setEnumeratorColumnMapping,
   setMappingErrorList,
+  setMappingErrorCount,
   setMappingErrorStatus,
   postEnumeratorsMappingFailure,
   postEnumeratorsMappingRequest,

--- a/src/redux/targets/targetSlice.ts
+++ b/src/redux/targets/targetSlice.ts
@@ -9,6 +9,10 @@ interface TagertsState {
   csvRows: string[];
   targetsList: string[];
   targetsColumnConfig: any;
+  targetsColumnMapping: any;
+  mappingErrorStatus: boolean;
+  mappingErrorList: any;
+  mappingErrorCount: number;
   targetDetails: any;
 }
 
@@ -22,6 +26,10 @@ const initialState: TagertsState = {
   targetsList: [],
   targetDetails: {},
   targetsColumnConfig: null,
+  targetsColumnMapping: null,
+  mappingErrorStatus: false,
+  mappingErrorList: null,
+  mappingErrorCount: 0,
 };
 
 const targetsSlice = createSlice({
@@ -56,6 +64,18 @@ const targetsSlice = createSlice({
     },
     setLoading: (state, action: PayloadAction<any>) => {
       state.loading = action.payload;
+    },
+    setTargetsColumnMapping: (state, action: PayloadAction<any>) => {
+      state.targetsColumnMapping = action.payload;
+    },
+    setMappingErrorStatus: (state, action: PayloadAction<any>) => {
+      state.mappingErrorStatus = action.payload;
+    },
+    setMappingErrorList: (state, action: PayloadAction<any>) => {
+      state.mappingErrorList = action.payload;
+    },
+    setMappingErrorCount: (state, action: PayloadAction<any>) => {
+      state.mappingErrorCount = action.payload;
     },
 
     getTargetsRequest: (state) => {
@@ -151,6 +171,10 @@ export const {
   setTargetsFileUpload,
   setTargetsCSVRows,
   setLoading,
+  setTargetsColumnMapping,
+  setMappingErrorList,
+  setMappingErrorCount,
+  setMappingErrorStatus,
   postTargetsMappingFailure,
   postTargetsMappingRequest,
   postTargetsMappingSuccess,

--- a/src/redux/targets/types.ts
+++ b/src/redux/targets/types.ts
@@ -10,5 +10,5 @@ export type TargetMapping = {
     target_id: string;
   };
   file: string;
-  mode: "overwrite" | "append";
+  mode: "overwrite" | "merge";
 };


### PR DESCRIPTION
## [SS-1272] <Targets Merge Functionality Integration> Targets Merge Functionality Integration

This PR integrates the targets merge functionality to the target screens.

## Ticket

Fixes: https://idinsight.atlassian.net/browse/SS-1272

## Description, Motivation and Context
- exclude custom_fields from list of available columns on enumerators
- add global redux setMappingErrorCount for enumerators and use it to show no of errors on remap
- add loading screen on remap to allow all fields to load before rendering form
- eliminate additional fields on targets column mapping setup
- redirect to targets upload on targets home if no targets exist
- set columns available using column_mapping data from targets list
- use global redux to set errors and error count on targets remap upload
-  add loading screen for targets remap screen to allow all fields to render before showing form
- upload data using the merge mode on targets reupload
- display columns set by column_mapping as available columns on the reupload screen for targets
- add mappingErrorCount to enumerators slice
- update target mapping type mode to contain merge

## How Has This Been Tested?
 - local dev


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have written [good commit messages][1]


[SS-1272]: https://idinsight.atlassian.net/browse/SS-1272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ