### PR TITLE
[SS-1307] Fix active state on header navigation item

### DIFF
--- a/src/components/NavItems/NavItems.css
+++ b/src/components/NavItems/NavItems.css
@@ -11,7 +11,9 @@
     display: block;
 }
 
-.nav-menu-item, .nav-menu-item > div:first-child {
+.nav-menu-item,
+.nav-menu-item > div:first-child,
+.nav-menu-item > a {
     display: flex;
     align-items: center;
 }

--- a/src/components/NavItems/NavItems.tsx
+++ b/src/components/NavItems/NavItems.tsx
@@ -8,14 +8,21 @@ import {
 import "./NavItems.css";
 import { Link } from "react-router-dom";
 
+const isActiveItem = (path: string) => {
+  const currentPath = location.pathname;
+  return currentPath.includes(path) ? "bg-geekblue-5" : "";
+};
+
 const NavItems = () => {
   return (
     <div className="nav-menu flex">
-      <div className="nav-menu-item w-36 bg-geekblue-5">
-        <HomeFilled className="flex items-center !text-base !text-gray-2" />
-        <span className="!text-gray-2">Surveys</span>
+      <div className={"nav-menu-item  w-36 " + isActiveItem("surveys")}>
+        <Link to="/surveys">
+          <HomeFilled className="flex items-center !text-base !text-gray-2" />
+          <span className="!text-gray-2">Surveys</span>
+        </Link>
       </div>
-      <div className="nav-menu-item">
+      <div className={"nav-menu-item " + isActiveItem("users")}>
         <div>
           <ApartmentOutlined className="flex items-center !text-base !text-gray-2" />
           <span className="!text-gray-2">User management</span>


### PR DESCRIPTION
## [SS-1307] Fix active state on header navigation item

## Ticket

Fixes:https://idinsight.atlassian.net/browse/SS-1307

## Description, Motivation and Context
Make the navigation item to `geekblue-5` color when that tab is active.

## How Has This Been Tested?
Locally

## UI Changes
<img width="1440" alt="Screenshot 2023-11-23 at 12 04 12 PM" src="https://github.com/IDinsight/surveystream_react_app/assets/19777712/a9997c7c-92c5-407f-a1e5-4a109549d498">
<img width="1440" alt="Screenshot 2023-11-23 at 12 04 27 PM" src="https://github.com/IDinsight/surveystream_react_app/assets/19777712/f5816da6-965a-4f5f-972c-76c4cbd3d8b7">

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have written [good commit messages][1]

[SS-1307]: https://idinsight.atlassian.net/browse/SS-1307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ