### PR TITLE
[SS-1385] Upload Locations: Add Pagination

### DIFF
--- a/src/modules/SurveyInformation/SurveyLocationUpload/LocationTable.tsx
+++ b/src/modules/SurveyInformation/SurveyLocationUpload/LocationTable.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { Button, Table } from "antd";
 import styled from "styled-components";
 import { CloudDownloadOutlined } from "@ant-design/icons";
@@ -23,6 +23,7 @@ interface LocationTableProps {
 
 const LocationTable: React.FC<LocationTableProps> = ({ columns, data }) => {
   const { CSVDownloader, Type } = useCSVDownloader();
+  const [paginationPageSize, setPaginationPageSize] = useState<number>(25);
 
   const transformedColumns = columns.map((label: string) => {
     return {
@@ -71,7 +72,13 @@ const LocationTable: React.FC<LocationTableProps> = ({ columns, data }) => {
       <TableA
         columns={transformedColumns}
         dataSource={transformedData}
-        pagination={false}
+        pagination={{
+          pageSize: paginationPageSize,
+          pageSizeOptions: [25, 50, 100],
+          showSizeChanger: true,
+          showQuickJumper: true,
+          onShowSizeChange: (_, size) => setPaginationPageSize(size),
+        }}
         style={{ marginRight: "80px", marginTop: "18px" }}
       />
     </>


### PR DESCRIPTION
## [SS-1385] Upload Locations: Add Pagination

## Ticket

Fixes: https://idinsight.atlassian.net/browse/SS-1385

## Description, Motivation and Context
Adding pagination to upload location screen. Default size of per page is 25.

## How Has This Been Tested?
Locally

## UI Changes
<img width="1440" alt="Screenshot 2024-01-02 at 3 30 49 PM" src="https://github.com/IDinsight/surveystream_react_app/assets/19777712/5e2dc662-e04f-4d24-8726-a2e6ffb89328">


## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have written [good commit messages][1]

[SS-1385]: https://idinsight.atlassian.net/browse/SS-1385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ