### PR TITLE
[SS-1492] Remove calling hooks conditionally

### DIFF
--- a/src/modules/Assignments/Assignments.tsx
+++ b/src/modules/Assignments/Assignments.tsx
@@ -47,11 +47,6 @@ function Assignments() {
     form_uid: string;
   }>();
 
-  // Ensure that the survey_uid are available
-  if (!survey_uid) {
-    return <NotFound />;
-  }
-
   // Fetch the data from the store
   const form = useAppSelector(
     (state: RootState) => state.surveyCTOInformation.surveyCTOForm
@@ -256,6 +251,8 @@ function Assignments() {
 
   // Ensure that the form_uid is available
   useEffect(() => {
+    if (survey_uid == "" || survey_uid == undefined) return;
+
     if (form_uid == "" || form_uid == undefined) {
       const resp = dispatch(getSurveyCTOForm({ survey_uid }));
       resp.then((res) => {
@@ -271,6 +268,7 @@ function Assignments() {
 
   // Dispatch the actions to populate the data
   useEffect(() => {
+    if (survey_uid == "" || survey_uid == undefined) return;
     if (form_uid == "" || form_uid == undefined) return;
     dispatch(getSurveyCTOForm({ survey_uid }));
     dispatch(getTableConfig({ formUID: form_uid || "" }));
@@ -382,6 +380,11 @@ function Assignments() {
 
   // Checking if the data is loading
   const isLoading: boolean = tableConfigLoading && assignmentsLoading;
+
+  // Ensure that the survey_uid are available
+  if (!survey_uid) {
+    return <NotFound />;
+  }
 
   return (
     <>


### PR DESCRIPTION
## [SS-1492] Remove calling hooks conditionally

## Ticket

Fixes: https://idinsight.atlassian.net/browse/SS-1492

## Description, Motivation and Context

While returning something before the execution of the hook is giving the "React Hook "useEffect" is called conditionally" error. This PR is fixing the error by moving the return at last in component.

## How Has This Been Tested?
Yes with running `docker build -f Dockerfile.client --build-arg BUILD_ENV=staging --rm --platform=linux/amd64 -t  surveystream_frontend:0.1 .`

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have written [good commit messages][1]

[SS-1492]: https://idinsight.atlassian.net/browse/SS-1492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ