### PR TITLE
[SS-1509] Increase Nginx's timeout and client body size

### DIFF
--- a/nginx.default.conf
+++ b/nginx.default.conf
@@ -15,6 +15,11 @@ server {
     gzip_min_length 256;
     gzip_types text/plain application/json text/html text/css text/javascript;
 
+    proxy_connect_timeout       300;
+    proxy_send_timeout          300;
+    proxy_read_timeout          300;
+    client_max_body_size        80m;
+
     location / {
         try_files $uri $uri/ /index.html;
         add_header Cache-Control "no-cache";

--- a/nginx.test.conf
+++ b/nginx.test.conf
@@ -15,6 +15,11 @@ server {
     gzip_min_length 256;
     gzip_types text/plain application/json text/html text/css text/javascript;
 
+    proxy_connect_timeout       300;
+    proxy_send_timeout          300;
+    proxy_read_timeout          300;
+    client_max_body_size        80m;
+
     location / {
         try_files $uri $uri/ /index.html;
         add_header Cache-Control "no-cache";


### PR DESCRIPTION
## [SS-1509] Increase Nginx's timeout and client body size

## Ticket

Fixes: https://idinsight.atlassian.net/browse/SS-1509

## Description, Motivation and Context

- What is the goal of the PR?
Airflow is getting error 504 from the server due to the limitation of the Nginx server to return the response in 1 minute. This PR goal is to increase the timeout and response size limit of the server to fix this issue.

- What are the changes to achieve that goal?
Adding `timeout` and `client_max_body_size` config in the Nginx file.

- Why have you chosen this solution?
This is a build-in optional config provided by Nginx server software.

## How Has This Been Tested?
It has been tested in the past on v1.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have written [good commit messages][1]

[SS-1509]: https://idinsight.atlassian.net/browse/SS-1509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ