### PR TITLE
[Hotfix] Cherry-pick (SS-1509): Increase Nginx's timeout and body size

### DIFF
--- a/nginx.default.conf
+++ b/nginx.default.conf
@@ -15,6 +15,11 @@ server {
     gzip_min_length 256;
     gzip_types text/plain application/json text/html text/css text/javascript;
 
+    proxy_connect_timeout       300;
+    proxy_send_timeout          300;
+    proxy_read_timeout          300;
+    client_max_body_size        80m;
+
     location / {
         try_files $uri $uri/ /index.html;
         add_header Cache-Control "no-cache";

--- a/nginx.test.conf
+++ b/nginx.test.conf
@@ -15,6 +15,11 @@ server {
     gzip_min_length 256;
     gzip_types text/plain application/json text/html text/css text/javascript;
 
+    proxy_connect_timeout       300;
+    proxy_send_timeout          300;
+    proxy_read_timeout          300;
+    client_max_body_size        80m;
+
     location / {
         try_files $uri $uri/ /index.html;
         add_header Cache-Control "no-cache";


### PR DESCRIPTION
Hotfix: Increase Nginx Timeout for Production Environment

This hotfix addresses timeout errors occurring on the https://callisto.surveystream.idinsight.io/api/targets?form_uid=6 endpoint, affecting users in the production environment. The Nginx timeout has been increased to 5 minutes to deal with these issues.