### PR TITLE
[DDSSPB-105] Update the assignment on surveyor dropout

### DIFF
--- a/src/redux/assignments/assignmentsActions.ts
+++ b/src/redux/assignments/assignmentsActions.ts
@@ -154,6 +154,11 @@ export const updateEnumeratorStatus = createAsyncThunk(
       );
       if (response.status == 200) {
         dispatch(getEnumerators({ formUID }));
+
+        // Update the assignments list if the surveyor is dropout
+        if (newStatus === "Dropout") {
+          dispatch(getAssignments({ formUID }));
+        }
         return { ...response, success: true };
       }
 


### PR DESCRIPTION
## [DDSSPB-105] Update the assignment on surveyor dropout

## Ticket

Fixes: https://idinsight.atlassian.net/browse/DDSSPB-105

## Description, Motivation and Context
If a user marked the surveyor as dropout then we must refresh the assignment data as we make release the assignment from surveyor on dropout case. 

## How Has This Been Tested?
Yes, locally

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have written [good commit messages][1]

[DDSSPB-105]: https://idinsight.atlassian.net/browse/DDSSPB-105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ