### PR TITLE
[DDSSPB-159] Show correct alert message for inactive user

### DIFF
--- a/src/modules/Auth/Login/Login.tsx
+++ b/src/modules/Auth/Login/Login.tsx
@@ -33,10 +33,20 @@ const Login = () => {
 
       const loginResponse = await dispatch(performLogin(values));
 
-      if (loginResponse.payload == false) {
+      if (loginResponse.payload?.status == false) {
+        let errorMsg = "";
+        if (loginResponse.payload.error === "INACTIVE_USER") {
+          errorMsg =
+            "You cannot log in because your account is inactive. Please contact the SurveyStream team.";
+        } else if (loginResponse.payload.error === "UNAUTHORIZED") {
+          errorMsg =
+            "Login failed, kindly check your credentials and try again.";
+        } else {
+          errorMsg = "Something went wrong!";
+        }
         messageApi.open({
           type: "error",
-          content: "Login failed, kindly check your credentials and try again",
+          content: errorMsg,
         });
         return false;
       }

--- a/src/redux/auth/authActions.ts
+++ b/src/redux/auth/authActions.ts
@@ -35,7 +35,7 @@ export const performLogin = createAsyncThunk(
 
       if (response.status === false) {
         dispatch(loginFailure(response.error as string));
-        return false;
+        return response;
       }
 
       dispatch(loginSuccess(response));


### PR DESCRIPTION
## [DDSSPB-159] Show correct alert message for inactive user

## Ticket

Fixes: https://idinsight.atlassian.net/browse/DDSSPB-159

## Description, Motivation and Context
Currently, there is a wrong credentials alert message for inactive users which is wrong. In v1, we have different message for inactive users. This PR is porting those chagnes.

## How Has This Been Tested?
Tested locally via marking account as inactive from pgAdmin.

## UI Changes
<img width="1440" alt="Screenshot 2024-04-05 at 1 24 55 PM" src="https://github.com/IDinsight/surveystream_react_app/assets/19777712/c667184b-1f04-41d6-8c04-163de224ec28">

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have written [good commit messages][1]

[DDSSPB-159]: https://idinsight.atlassian.net/browse/DDSSPB-159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ