### PR TITLE
[Minor] - Update staging url on react

### DIFF
--- a/.env.staging
+++ b/.env.staging
@@ -1,4 +1,4 @@
 REACT_APP_SENTRY_DSN = "https://94cd1060a80d48328a2f38364e60f1c5@o564222.ingest.sentry.io/4505071111110656"
 REACT_APP_SENTRY_ENVIRONMENT = staging-callisto
-REACT_APP_API_BASE_URL = 'https://callisto.stg.surveystream.idinsight.io/api'
+REACT_APP_API_BASE_URL = 'https://stg.surveystream.idinsight.io/api'
 REACT_APP_MAX_UPLOAD_ROWS = 15000


### PR DESCRIPTION
## [Minor] - Update staging url

## Ticket
Not created

## Description, Motivation and Context

Since staging was moved to https://stg.surveystream.idinsight.io/, making required change on the staging environment file
Haven't changed the sentry environment value which is currently "staging-callisto"

## How Has This Been Tested?
Not tested

## To-do before merge
None
