### PR TITLE
[SS-1856] Fix the nagivation issue on back button

### DIFF
--- a/src/components/HandleBackButton/HandleBack.tsx
+++ b/src/components/HandleBackButton/HandleBack.tsx
@@ -1,18 +1,21 @@
 import { BackArrow, BackLink } from "../../shared/Nav.styled";
 import { useNavigate, useParams } from "react-router-dom";
-import { useAppDispatch, useAppSelector } from "../../redux/hooks";
 
-const HandleBack = () => {
+const HandleBack = ({ surveyPage }: { surveyPage?: boolean }) => {
   const { survey_uid } = useParams<{ survey_uid: string }>() ?? {
     survey_uid: "",
   };
   const navigate = useNavigate();
 
   const handleGoBack = () => {
-    if (window.history.length > 1) {
-      navigate(-1);
-    } else {
+    if (surveyPage) {
       navigate(`/survey-configuration/${survey_uid}`);
+    } else {
+      if (window.history.length > 1) {
+        navigate(-1);
+      } else {
+        navigate(`/survey-configuration/${survey_uid}`);
+      }
     }
   };
 

--- a/src/components/Layout/Container.tsx
+++ b/src/components/Layout/Container.tsx
@@ -11,9 +11,10 @@ import { setActiveSurvey } from "../../redux/surveyList/surveysSlice";
 
 interface IContainer {
   children?: ReactNode;
+  surveyPage?: boolean;
 }
 
-const Container: React.FC<IContainer> = ({ children }) => {
+const Container: React.FC<IContainer> = ({ children, surveyPage }) => {
   const dispatch = useAppDispatch();
   const { survey_uid } = useParams<{ survey_uid: string }>() ?? {
     survey_uid: "",
@@ -44,7 +45,7 @@ const Container: React.FC<IContainer> = ({ children }) => {
   return (
     <>
       <Wrapper>
-        <HandleBackButton />
+        <HandleBackButton surveyPage={surveyPage} />
         <Title>{activeSurvey?.survey_name}</Title>
         {children}
       </Wrapper>

--- a/src/modules/Assignments/Assignments.tsx
+++ b/src/modules/Assignments/Assignments.tsx
@@ -411,7 +411,7 @@ function Assignments() {
         <FullScreenLoader />
       ) : (
         <>
-          <Container />
+          <Container surveyPage={true} />
           <div>
             <HeaderContainer>
               <Title>Assignments</Title>

--- a/src/modules/Assignments/TableConfig/TableConfig.tsx
+++ b/src/modules/Assignments/TableConfig/TableConfig.tsx
@@ -577,7 +577,7 @@ function TableConfig() {
         <FullScreenLoader />
       ) : (
         <>
-          <Container />
+          <Container surveyPage={tableKey ? false : true} />
           <HeaderContainer>
             <Title>Assignments Column Configuration</Title>
             <div style={{ marginLeft: "auto" }}>

--- a/src/modules/Emails/Emails.tsx
+++ b/src/modules/Emails/Emails.tsx
@@ -174,7 +174,7 @@ function Emails() {
     <>
       <GlobalStyle />
       <Header />
-      <Container />
+      <Container surveyPage={true} />
       <HeaderContainer>
         <Title>Emails</Title>
         <div style={{ marginLeft: "auto" }}>

--- a/src/modules/SurveyInformation/Enumerators/EnumeratorsHome/EnumeratorsHome.tsx
+++ b/src/modules/SurveyInformation/Enumerators/EnumeratorsHome/EnumeratorsHome.tsx
@@ -392,7 +392,7 @@ function EnumeratorsHome() {
     <>
       <GlobalStyle />
       <Header />
-      <Container />
+      <Container surveyPage={true} />
       <HeaderContainer>
         <Title>Enumerators</Title>
         {screenMode == "manage" ? (

--- a/src/modules/SurveyInformation/Enumerators/EnumeratorsMap/EnumeratorsMap.tsx
+++ b/src/modules/SurveyInformation/Enumerators/EnumeratorsMap/EnumeratorsMap.tsx
@@ -438,7 +438,7 @@ function EnumeratorsMap() {
       <GlobalStyle />
       <Header />
       <NavWrapper>
-        <HandleBackButton></HandleBackButton>
+        <HandleBackButton surveyPage={true}></HandleBackButton>
 
         <Title>
           {(() => {

--- a/src/modules/SurveyInformation/Enumerators/EnumeratorsUpload/EnumeratorsUpload.tsx
+++ b/src/modules/SurveyInformation/Enumerators/EnumeratorsUpload/EnumeratorsUpload.tsx
@@ -144,7 +144,7 @@ function EnumeratorsUpload() {
       <GlobalStyle />
       <Header />
       <NavWrapper>
-        <HandleBackButton></HandleBackButton>
+        <HandleBackButton surveyPage={true}></HandleBackButton>
 
         <Title> {activeSurvey?.survey_name} </Title>
       </NavWrapper>

--- a/src/modules/SurveyInformation/Targets/TargetsHome/TargetsHome.tsx
+++ b/src/modules/SurveyInformation/Targets/TargetsHome/TargetsHome.tsx
@@ -338,7 +338,7 @@ function TargetsHome() {
     <>
       <GlobalStyle />
       <Header />
-      <Container />
+      <Container surveyPage={true} />
       <HeaderContainer>
         <Title>Targets</Title>
 

--- a/src/modules/SurveyInformation/Targets/TargetsUpload/TargetsUpload.tsx
+++ b/src/modules/SurveyInformation/Targets/TargetsUpload/TargetsUpload.tsx
@@ -135,7 +135,7 @@ function TargetsUpload() {
       <GlobalStyle />
       <Header />
       <NavWrapper>
-        <HandleBackButton></HandleBackButton>
+        <HandleBackButton surveyPage={true}></HandleBackButton>
 
         <Title>
           {(() => {


### PR DESCRIPTION
## [SS-1856] Fix the navigation issue on the back button

## Ticket

Fixes: https://idinsight.atlassian.net/browse/SS-1856

## Description, Motivation and Context
Fixes the navigation issues. The main cause handling the form uid. Example:

User visit to /module-configuration/table-config/<survey_uid> then we have handleFormUID function to redirect it /module-configuration/table-config/<survey_uid>/<form_uid>.

So if the user clicks on the back button. It takes them to the first URL and the handleFormUID function is triggered again which redirects the user to the same form_uid page. This loop goes on. So the solution is when the user is on the page where handleFormUID is getting run then those pages should go to /survey-configuration/<survey_uid> on back button click.

## How Has This Been Tested?
Locally

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have written [good commit messages][1]

[SS-1856]: https://idinsight.atlassian.net/browse/SS-1856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ