### PR TITLE
[DDSSPB-166] Fix missing form uid on SCTO Questions Screen

### DIFF
--- a/src/modules/SurveyInformation/SurveyCTOQuestions/SurveyCTOQuestions.tsx
+++ b/src/modules/SurveyInformation/SurveyCTOQuestions/SurveyCTOQuestions.tsx
@@ -45,6 +45,7 @@ import { SurveyCTOQuestionsForm } from "../../../redux/surveyCTOQuestions/types"
 import { GlobalStyle } from "../../../shared/Global.styled";
 import HandleBackButton from "../../../components/HandleBackButton";
 import Container from "../../../components/Layout/Container";
+import { getSurveyCTOForm } from "../../../redux/surveyCTOInformation/surveyCTOInformationActions";
 
 function SurveyCTOQuestions() {
   const [form] = Form.useForm();
@@ -298,11 +299,38 @@ function SurveyCTOQuestions() {
     }
   };
 
+  const handleFormUID = () => {
+    if (form_uid == "" || form_uid == undefined || form_uid == "undefined") {
+      try {
+        const sctoForm = dispatch(
+          getSurveyCTOForm({ survey_uid: survey_uid })
+        ).then((res) => {
+          if (res.payload[0]?.form_uid) {
+            navigate(
+              `/survey-information/survey-cto-questions/${survey_uid}/${res.payload[0]?.form_uid}`
+            );
+          } else {
+            message.error("Kindly configure SCTO Form to proceed");
+            navigate(
+              `/survey-information/survey-cto-information/${survey_uid}`
+            );
+          }
+        });
+      } catch (error) {
+        console.log("Error fetching sctoForm:", error);
+      }
+    }
+  };
+
   useEffect(() => {
-    loadFormQuestions();
-    fetchSurveyLocationGeoLevels();
-    loadFormMappings();
-  }, []);
+    handleFormUID();
+
+    if (form_uid) {
+      loadFormQuestions();
+      fetchSurveyLocationGeoLevels();
+      loadFormMappings();
+    }
+  }, [navigate]);
 
   return (
     <>


### PR DESCRIPTION
## [DDSSPB-166] Fix missing form uid on SCTO Questions Screen

## Ticket

Fixes: https://idinsight.atlassian.net/browse/DDSSPB-166

## Description, Motivation and Context
If form uid is not present then handle it by fetch scto form and redirect with form uid.

## How Has This Been Tested?
Locally

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have written [good commit messages][1]

[DDSSPB-166]: https://idinsight.atlassian.net/browse/DDSSPB-166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ