### PR TITLE
[DDSSPB-169, Bugfix] - Prime Geo Level gets reset when updating basic information

### DIFF
--- a/src/modules/NewSurveyConfig/BasicInformation/BasicInformationForm.tsx
+++ b/src/modules/NewSurveyConfig/BasicInformation/BasicInformationForm.tsx
@@ -91,6 +91,9 @@ const BasicInformationForm: React.FC<BasicInformationFormProps> = ({
         ? basicInfo?.config_status
         : "In Progress - Configuration",
       state: basicInfo?.state ? basicInfo?.state : "Draft",
+      prime_geo_level_uid: basicInfo?.prime_geo_level_uid
+        ? basicInfo?.prime_geo_level_uid
+        : null,
       created_by_user_uid: userUId,
     };
   };


### PR DESCRIPTION
## [DDSSPB-169, Bugfix] - Prime Geo Level gets reset when updating basic information

## Ticket

Fixes: https://idinsight.atlassian.net/browse/DDSSPB-169

## Description, Motivation and Context

This PR fixes the issue of prime geo level getting reset when saving basic information by reading it from fetched information and passing it to the save function.

## How Has This Been Tested?
Tested on local

## UI Changes
NA

## To-do before merge
None

## Checklist:

This checklist is a useful reminder of small things that can easily be forgotten.
Put an `x` in all the items that apply and remove any items that are not relevant to this PR.

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- ~~[ ] I have updated the automated tests (if applicable)~~
- [x] I have written [good commit messages][1]
- ~~[ ] I have updated the README file (if applicable)~~
- ~~[ ] I have updated affected documentation (if applicable)~~

[DDSSPB-169]: https://idinsight.atlassian.net/browse/DDSSPB-169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ