### PR TITLE
[DDSSPB-173] Bugfix: custom fields not saving on enumerators csv upload

### DIFF
--- a/src/modules/SurveyInformation/Enumerators/EnumeratorsMap/EnumeratorsMap.tsx
+++ b/src/modules/SurveyInformation/Enumerators/EnumeratorsMap/EnumeratorsMap.tsx
@@ -225,13 +225,16 @@ function EnumeratorsMap() {
       setErrorCount(0);
       const values = await enumeratorMappingForm.validateFields();
       const column_mapping = enumeratorMappingForm.getFieldsValue();
-      column_mapping.custom_fields = {};
+      column_mapping.custom_fields = [];
       if (customHeaderSelection) {
         for (const [column_name, shouldInclude] of Object.entries(
           customHeaderSelection
         )) {
           if (shouldInclude) {
-            column_mapping["custom_fields"][column_name] = column_name; // Set the column_type to "custom_fields"
+            column_mapping.custom_fields.push({
+              column_name: column_name,
+              field_label: column_name,
+            });
           }
         }
       }
@@ -350,7 +353,7 @@ function EnumeratorsMap() {
                   column_type: personal
                     ? "personal_details"
                     : location
-                    ? "location_details"
+                    ? "location"
                     : "custom_fields",
                 };
               }

--- a/src/modules/SurveyInformation/Enumerators/EnumeratorsRemap/EnumeratorsRemap.tsx
+++ b/src/modules/SurveyInformation/Enumerators/EnumeratorsRemap/EnumeratorsRemap.tsx
@@ -248,13 +248,16 @@ function EnumeratorsRemap({ setScreenMode }: IEnumeratorsReupload) {
       dispatch(setMappingErrorCount(0));
       const values = await enumeratorMappingForm.validateFields();
       const column_mapping = enumeratorMappingForm.getFieldsValue();
-      column_mapping.custom_fields = {};
+      column_mapping.custom_fields = [];
       if (customHeaderSelection) {
         for (const [column_name, shouldInclude] of Object.entries(
           customHeaderSelection
         )) {
           if (shouldInclude) {
-            column_mapping["custom_fields"][column_name] = column_name; // Set the column_type to "custom_fields"
+            column_mapping.custom_fields.push({
+              column_name: column_name,
+              field_label: column_name,
+            });
           }
         }
       }


### PR DESCRIPTION
# [DDSSPB-173] Bugfix: custom fields not saving on enumerators csv upload

## Ticket

Fixes: https://idinsight.atlassian.net/browse/DDSSPB-173

## Description, Motivation and Context

This PR fixes a bug where custom fields are not saving when uploading the enumerators csv file. The root cause is that the payload is not formed correctly: it should be an array of objects rather than an object. Note that the targets upload module uses the correct array of objects payload format.

Another issue was found (and is fixed here) when investigating this bug: the enumerators column config does not appear to be saving due to an error. This is because the column type for the prime geo level id should be `location` rather than `location_details`.

## How Has This Been Tested?

Tested manually on local.

## Checklist:

This checklist is a useful reminder of small things that can easily be forgotten.
Put an `x` in all the items that apply and remove any items that are not relevant to this PR.

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have updated the automated tests (if applicable)
- [x] I have written [good commit messages][1]
- [x] I have updated the README file (if applicable)
- [x] I have updated affected documentation (if applicable)

[DDSSPB-173]: https://idinsight.atlassian.net/browse/DDSSPB-173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ