### PR TITLE
[Hotfix] Fix the React Hook calls

### DIFF
--- a/src/modules/Assignments/TableConfig/TableConfig.tsx
+++ b/src/modules/Assignments/TableConfig/TableConfig.tsx
@@ -63,11 +63,6 @@ function TableConfig() {
     form_uid: string;
   }>();
 
-  // Ensure that the survey_uid are available
-  if (!survey_uid) {
-    return <NotFound />;
-  }
-
   const {
     loading: isTableConfigLoading,
     data: tableConfig,
@@ -568,6 +563,11 @@ function TableConfig() {
   useEffect(() => {
     setDefaultSelectedCols();
   }, [selectedColumns, sctoColumns, otherColumns]);
+
+  // Ensure that the survey_uid are available
+  if (!survey_uid) {
+    return <NotFound />;
+  }
 
   return (
     <>

--- a/src/modules/Emails/ConfigureEmails/EmailScheduleForm.tsx
+++ b/src/modules/Emails/ConfigureEmails/EmailScheduleForm.tsx
@@ -32,6 +32,7 @@ const EmailScheduleForm = ({
     (state: RootState) => state.emails
   );
   const [currentFormIndex, setCurrentFormIndex] = useState<number | null>(null);
+  const [activeKey, setActiveKey] = useState<string | string[]>(["0"]);
 
   const [loading, setLoading] = useState(false);
   const [insertScheduleFilterOpen, setScheduleFilterOpen] = useState(false);
@@ -162,8 +163,6 @@ const EmailScheduleForm = ({
   if (loading || isLoading) {
     return <FullScreenLoader />;
   }
-
-  const [activeKey, setActiveKey] = useState<string | string[]>(["0"]);
 
   return (
     <Form form={form} layout="vertical">


### PR DESCRIPTION
## [Hotfix] Fix the React Hook calls

## Description, Motivation and Context
Fixing `React Hook "useAppSelector" is called conditionally. React Hooks must be called in the exact same order in every component render` error by moving the return of component at the end.

## How Has This Been Tested?
Locally

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have written [good commit messages][1]
- [x] I have updated the README file (if applicable)