### PR TITLE
[MINOR] - Minor change to delete button hover colors

### DIFF
--- a/src/components/AdminFormCard/AdminFormCard.styled.ts
+++ b/src/components/AdminFormCard/AdminFormCard.styled.ts
@@ -5,7 +5,7 @@ export const DeleteBtn = styled(Button)`
   margin-top: 24px;
   margin-left: 12px;
   &:hover {
-    background-color: red;
-    color: white !important;
+    background-color: white !important;
+    color: red !important;
   }
 `;

--- a/src/components/DQFormCard/DQFormCard.styled.ts
+++ b/src/components/DQFormCard/DQFormCard.styled.ts
@@ -5,7 +5,7 @@ export const DeleteBtn = styled(Button)`
   margin-top: 24px;
   margin-left: 12px;
   &:hover {
-    background-color: red;
-    color: white !important;
+    background-color: white !important;
+    color: red !important;
   }
 `;

--- a/src/components/MediaForm/MediaForm.styled.ts
+++ b/src/components/MediaForm/MediaForm.styled.ts
@@ -5,7 +5,7 @@ export const DeleteBtn = styled(Button)`
   margin-top: 24px;
   margin-left: 12px;
   &:hover {
-    background-color: red;
-    color: white !important;
+    background-color: white !important;
+    color: red !important;
   }
 `;


### PR DESCRIPTION
## [MINOR] - Minor change to delete button hover colors

## Ticket

Not created

## Description, Motivation and Context
The delete button text was changing to white on hover which made the text not legible as shown in the below screenshot (first button is when hovered):
<img width="1048" alt="Screenshot 2024-10-11 at 1 28 30 PM" src="https://github.com/user-attachments/assets/d4b8537c-6cb2-4f96-9e54-e5d92bb9544a">


Updated the color of text to "red" on hover as shown in the below screenshot (first button is when hovered):
<img width="1010" alt="Screenshot 2024-10-11 at 1 27 22 PM" src="https://github.com/user-attachments/assets/44f61adf-9275-47d7-acd3-97d4c1dd3e67">

Same change has been replicated across DQ forms, Media files and Admin form screens.

## How Has This Been Tested?
On local

## To-do before merge
None

## Checklist:

This checklist is a useful reminder of small things that can easily be forgotten.
Put an `x` in all the items that apply and remove any items that are not relevant to this PR.

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- ~~[ ] I have updated the automated tests (if applicable)~~
- [x] I have written [good commit messages][1]
- ~~[ ] I have updated the README file (if applicable)~~
- ~~[ ] I have updated affected documentation (if applicable)~~