### PR TITLE
[SS-1951] Update user profile on new survey and survey home page

### DIFF
--- a/src/modules/NewSurveyConfig/NewSurveyConfig.tsx
+++ b/src/modules/NewSurveyConfig/NewSurveyConfig.tsx
@@ -35,6 +35,7 @@ import {
   clearModuleQuestionnaire,
 } from "../../redux/surveyConfig/surveyConfigSlice";
 import { setActiveSurvey } from "../../redux/surveyList/surveysSlice";
+import { performGetUserProfile } from "../../redux/auth/authActions";
 
 export interface IStepIndex {
   sidebar: number;
@@ -300,6 +301,10 @@ function NewSurveyConfig() {
 
         window.history.replaceState(null, "", newURL);
         setSurveyUid(newSurveyUid);
+
+        // After saving the basic information, we need to update user profile
+        // because it contains the list of surveys the user has created as survey admin
+        dispatch(performGetUserProfile());
 
         if (stepIndex["sidebar"] < 1) {
           setStepIndex((prev: IStepIndex) => ({

--- a/src/modules/SurveyConfiguration/SurveyConfiguration.tsx
+++ b/src/modules/SurveyConfiguration/SurveyConfiguration.tsx
@@ -265,14 +265,10 @@ const SurveyConfiguration: React.FC = () => {
     return userHasPermission(userProfile, survey_uid, permission_name);
   };
 
-  const renderSection = (
-    sectionTitle: string,
-    sectionConfig: any,
-    index: number
-  ) => {
+  const renderSection = (sectionTitle: string, sectionConfig: any) => {
     if (Array.isArray(sectionConfig) && sectionConfig.length > 0) {
       return (
-        <div key={index}>
+        <>
           {sectionConfig.some((item: any) => checkPermissions(item?.name)) && (
             <SectionTitle>{`${sectionTitle}`}</SectionTitle>
           )}
@@ -310,7 +306,7 @@ const SurveyConfiguration: React.FC = () => {
               ) : null;
             })}
           </div>
-        </div>
+        </>
       );
     } else if (
       !Array.isArray(sectionConfig) &&
@@ -319,7 +315,7 @@ const SurveyConfiguration: React.FC = () => {
       const hasPermission = checkPermissions(sectionTitle);
 
       return hasPermission ? (
-        <div key={index}>
+        <>
           <SectionTitle>{`${sectionTitle}`}</SectionTitle>
 
           <Link
@@ -348,11 +344,10 @@ const SurveyConfiguration: React.FC = () => {
               {renderStatus(sectionConfig.status)}
             </StyledCard>
           </Link>
-        </div>
+        </>
       ) : null;
     } else {
       <Result
-        key={index}
         title={"Reload Configuration"}
         subTitle={"Failed to load configuration, kindly reload"}
         extra={
@@ -401,7 +396,9 @@ const SurveyConfiguration: React.FC = () => {
           <MainWrapper>
             {Object.entries(surveyConfigs).map(
               ([sectionTitle, sectionConfig], index) => (
-                <>{renderSection(sectionTitle, sectionConfig, index)}</>
+                <div key={index}>
+                  {renderSection(sectionTitle, sectionConfig)}
+                </div>
               )
             )}
           </MainWrapper>

--- a/src/modules/SurveysHomePage/SurveysHomePage.tsx
+++ b/src/modules/SurveysHomePage/SurveysHomePage.tsx
@@ -26,13 +26,7 @@ function SurveysHomePage() {
 
   const showError = useAppSelector((state: RootState) => state.surveys.error);
   const fetchData = async () => {
-    let { user_uid } = userProfile;
-
-    if (!user_uid) {
-      const profile = await dispatch(performGetUserProfile());
-      user_uid = profile.payload.user_uid;
-    }
-
+    await dispatch(performGetUserProfile());
     await dispatch(fetchSurveys());
   };
 
@@ -123,7 +117,7 @@ function SurveysHomePage() {
                             </NewSurveyCard>
                           </StyledLink>
                         ) : null}
-                        {draftSurveys.map((survey, index: number) => (
+                        {draftSurveys.map((survey) => (
                           <div key={survey.survey_uid}>
                             <SurveyCard
                               title={survey.survey_name}


### PR DESCRIPTION
## [SS-1951] Update user profile on new survey and survey home page

## Ticket

Fixes: https://idinsight.atlassian.net/browse/SS-1951

## Description, Motivation and Context

The user profile contains the admin_surveys which includes the survey uids associated with the user. On survey creation, this does not update user profile, so visiting the survey page shows a blank screen because it checks the module permission on user profile. Since, user profile does not updated. It uses the old state from localStorage to check permissions.

Solution: Make sure to update the profile at some intervals. The best case is to survey the home page.

Also, fixing the unique key error on the Survey Configuration Page.


## How Has This Been Tested?
Locally with survey admin demo account at http://localhost:3000/survey-configuration/565

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have written [good commit messages][1]

[SS-1951]: https://idinsight.atlassian.net/browse/SS-1951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ