### PR TITLE
[SS-1952] - Adding delete button on mapping config rows

### DIFF
--- a/src/modules/Mapping/Mapping.styled.tsx
+++ b/src/modules/Mapping/Mapping.styled.tsx
@@ -32,6 +32,12 @@ export const ResetButton = styled(Button)`
   }
 `;
 
+export const DeleteButton = styled(Button)`
+  &:hover {
+    color: red !important;
+  }
+`;
+
 export const MappingTable = styled(Table)`
   overflow: auto;
   margin-top: 15px;

--- a/src/modules/Mapping/MappingManage.tsx
+++ b/src/modules/Mapping/MappingManage.tsx
@@ -6,7 +6,7 @@ import FullScreenLoader from "../../components/Loaders/FullScreenLoader";
 import { HeaderContainer, Title } from "../../shared/Nav.styled";
 import { getSurveyCTOForm } from "../../redux/surveyCTOInformation/surveyCTOInformationActions";
 import { RootState } from "../../redux/store";
-import { Col, Row, Select, Tooltip } from "antd";
+import { Col, Row, Select, Tag, Tooltip } from "antd";
 import { properCase, userHasPermission } from "../../utils/helper";
 import { BodyContainer, CustomBtn, FormItemLabel } from "./Mapping.styled";
 import { QuestionCircleOutlined } from "@ant-design/icons";
@@ -102,8 +102,17 @@ function MappingManage() {
             {!form_uid ? (
               <>
                 <p>
-                  Map {properCase(mapping_name || "")}s to Supervisors based on:{" "}
-                  {criteria?.join(", ")}
+                  Map {mapping_name}s to supervisors based on{" "}
+                  <Tooltip title="As per mapping criteria selected under module questionnaire">
+                    <QuestionCircleOutlined />
+                  </Tooltip>{" "}
+                  :{" "}
+                  {
+                    // Display in tag format
+                    criteria.map((c) => (
+                      <Tag key={c}>{properCase(c)}</Tag>
+                    ))
+                  }
                 </p>
                 <Row align="middle" style={{ marginBottom: 6, marginTop: 12 }}>
                   <Col span={5}>

--- a/src/modules/Mapping/SurveyorMapping.tsx
+++ b/src/modules/Mapping/SurveyorMapping.tsx
@@ -8,10 +8,12 @@ import {
   Row,
   Col,
   Popconfirm,
+  Tooltip,
 } from "antd";
 import {
   fetchSurveyorsMappingConfig,
   updateSurveyorsMappingConfig,
+  deleteSurveyorsMappingConfig,
   resetSurveyorsMappingConfig,
   fetchUserGenders,
   fetchUserLanguages,
@@ -21,9 +23,15 @@ import {
 } from "../../redux/mapping/apiService";
 import { useNavigate } from "react-router-dom";
 import FullScreenLoader from "../../components/Loaders/FullScreenLoader";
-import { CustomBtn, MappingTable, ResetButton } from "./Mapping.styled";
+import {
+  CustomBtn,
+  MappingTable,
+  DeleteButton,
+  ResetButton,
+} from "./Mapping.styled";
 import { useAppDispatch } from "./../../redux/hooks";
 import { updateMappingStatsSuccess } from "./../../redux/mapping/mappingSlice";
+import { DeleteOutlined } from "@ant-design/icons";
 
 const { Option } = Select;
 
@@ -137,6 +145,31 @@ const SurveyorMapping = ({
       render: (status: any) => (
         <Tag color={status === "Complete" ? "green" : "red"}>{status}</Tag>
       ),
+    },
+    {
+      title: (
+        <Tooltip title="Delete action is enabled for rows with manually mapped mapping criteria values">
+          Action
+        </Tooltip>
+      ),
+      key: "action",
+      render: (_: any, record: any) =>
+        // show delete icon if the mapping columns don't match
+        record.surveyorLocation !== record.supervisorLocation ||
+        record.surveyorLanguage !== record.supervisorLanguage ||
+        record.surveyorGender !== record.supervisorGender ? (
+          <Popconfirm
+            title="Delete"
+            description="Are you sure you want to delete this mapping config?"
+            onConfirm={() => handleConfigDelete(record.config_uid)}
+            okText="Delete"
+            cancelText="No"
+          >
+            <DeleteButton type="link">
+              <DeleteOutlined />
+            </DeleteButton>
+          </Popconfirm>
+        ) : null,
     },
   ];
 
@@ -299,6 +332,7 @@ const SurveyorMapping = ({
         config.supervisor_mapping_criteria_values.criteria?.Gender,
       supervisorCount: config.supervisor_count,
       status: config.mapping_status,
+      config_uid: config.config_uid,
     };
   });
 
@@ -400,6 +434,27 @@ const SurveyorMapping = ({
     } else if (type === "Gender") {
       setSelectedGenders(updateState);
     }
+  };
+
+  const handleConfigDelete = (configUID: string) => {
+    setLoading(true);
+    deleteSurveyorsMappingConfig(formUID, configUID).then((res: any) => {
+      if (res?.data?.success) {
+        message.success("Mapping deleted successfully");
+        setLoading(true);
+        fetchSurveyorsMappingConfig(formUID).then((res: any) => {
+          if (res?.data?.success) {
+            setMappingConfig(res?.data?.data);
+          } else {
+            message.error("Failed to fetch mapping config");
+          }
+          setLoading(false);
+        });
+      } else {
+        message.error("Failed to delete mapping");
+      }
+      setLoading(false);
+    });
   };
 
   const handleConfigSave = () => {

--- a/src/redux/mapping/apiService.ts
+++ b/src/redux/mapping/apiService.ts
@@ -44,6 +44,28 @@ export const updateSurveyorsMappingConfig = async (
   }
 };
 
+export const deleteSurveyorsMappingConfig = async (
+  formUID: string,
+  configUID: string
+) => {
+  try {
+    await getCSRFToken();
+    const csrfToken = await getCookie("CSRF-TOKEN");
+    const url = `${API_BASE_URL}/mapping/surveyors-mapping-config?form_uid=${formUID}&config_uid=${configUID}`;
+
+    const res = await axios.delete(url, {
+      headers: {
+        "X-CSRF-Token": csrfToken,
+        "Content-Type": "application/json",
+      },
+      withCredentials: true,
+    });
+    return res;
+  } catch (error) {
+    return error;
+  }
+};
+
 export const resetSurveyorsMappingConfig = async (formUID: string) => {
   try {
     await getCSRFToken();
@@ -92,6 +114,28 @@ export const updateTargetsMappingConfig = async (
     const url = `${API_BASE_URL}/mapping/targets-mapping-config?form_uid=${formUID}`;
 
     const res = await axios.put(url, payload, {
+      headers: {
+        "X-CSRF-Token": csrfToken,
+        "Content-Type": "application/json",
+      },
+      withCredentials: true,
+    });
+    return res;
+  } catch (error) {
+    return error;
+  }
+};
+
+export const deleteTargetsMappingConfig = async (
+  formUID: string,
+  configUID: string
+) => {
+  try {
+    await getCSRFToken();
+    const csrfToken = await getCookie("CSRF-TOKEN");
+    const url = `${API_BASE_URL}/mapping/targets-mapping-config?form_uid=${formUID}&config_uid=${configUID}`;
+
+    const res = await axios.delete(url, {
       headers: {
         "X-CSRF-Token": csrfToken,
         "Content-Type": "application/json",
@@ -273,9 +317,11 @@ export const fetchUserGenders = async (survey_uid: string) => {
 export const api = {
   fetchSurveyorsMappingConfig,
   updateSurveyorsMappingConfig,
+  deleteSurveyorsMappingConfig,
   resetSurveyorsMappingConfig,
   fetchTargetsMappingConfig,
   updateTargetsMappingConfig,
+  deleteTargetsMappingConfig,
   resetTargetsMappingConfig,
   fetchSurveyorsMapping,
   fetchTargetsMapping,


### PR DESCRIPTION
## [SS-1952] - Adding delete button on mapping config rows

## Ticket

Fixes: https://idinsight.atlassian.net/browse/SS-1952

## Description, Motivation and Context

Adding a delete button to delete a single mapping config row on rows that are manually mapped. 

## How Has This Been Tested?
On local

## UI Changes
<img width="1457" alt="Screenshot 2024-10-31 at 12 57 26 PM" src="https://github.com/user-attachments/assets/2fbbdfc7-9269-4944-8107-557528a4c1c3">


## To-do before merge
- [ ] Ensure [backend changes](https://github.com/IDinsight/surveystream_flask_api/pull/242) are merged

## Checklist:

This checklist is a useful reminder of small things that can easily be forgotten.
Put an `x` in all the items that apply and remove any items that are not relevant to this PR.

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have updated the automated tests (if applicable)
- [x] I have written [good commit messages][1]
- [x] I have updated the README file (if applicable)
- ~~[ ] I have updated affected documentation (if applicable)~~

[SS-1952]: https://idinsight.atlassian.net/browse/SS-1952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ