### PR TITLE
[SS-1956, minor] - Updating timezone of time displayed on the assignments screen

### DIFF
--- a/src/modules/Assignments/Assignments.tsx
+++ b/src/modules/Assignments/Assignments.tsx
@@ -396,6 +396,31 @@ function Assignments() {
     },
   ];
 
+  const formatDate = (date: any, tz_name: string) => {
+    const options: Intl.DateTimeFormatOptions = {
+      weekday: "short",
+      day: "numeric",
+      month: "long",
+      year: "numeric",
+      hour: "numeric",
+      minute: "numeric",
+      second: "numeric",
+      timeZone: "UTC", // UTC is used to get the correct date and time
+    };
+
+    // find timezone abbreviation to append to the date
+    const timeZone = Intl.DateTimeFormat(undefined, {
+      timeZone: tz_name,
+      timeZoneName: "shortGeneric",
+    }).formatToParts();
+
+    return (
+      new Date(date).toLocaleDateString("en-US", options) +
+      " " +
+      timeZone[6].value
+    );
+  };
+
   // Checking if the data is loading
   const isLoading: boolean = tableConfigLoading || assignmentsLoading;
 
@@ -473,26 +498,14 @@ function Assignments() {
                         style={{
                           display: "flex",
                           color: "#595959",
-                          marginRight: 16,
                         }}
                       >
                         <p>
-                          Last updated: {form?.last_ingested_at ?? "Unknown"}
+                          Last updated on:{" "}
+                          {form?.last_ingested_at && form?.tz_name
+                            ? formatDate(form.last_ingested_at, form.tz_name)
+                            : "NA"}
                         </p>
-                      </div>
-                      <div
-                        style={{
-                          display: "flex",
-                          alignItems: "center",
-                          color: "#2F54EB",
-                          cursor: "pointer",
-                        }}
-                        onClick={() => window.open("#")}
-                      >
-                        <p>Assigning criteria</p>
-                        <ArrowUpOutlined
-                          style={{ fontSize: 16, transform: "rotate(45deg)" }}
-                        />
                       </div>
                     </div>
                   }

--- a/src/redux/surveyCTOInformation/surveyCTOInformationSlice.ts
+++ b/src/redux/surveyCTOInformation/surveyCTOInformationSlice.ts
@@ -12,7 +12,7 @@ const initialState: SurveyCTOInformationState = {
   loading: false,
   error: null,
   surveyCTOForm: {
-    last_ingested_at: "",
+    last_ingested_at: null,
     form_uid: "",
     survey_uid: "",
     scto_form_id: "",

--- a/src/redux/surveyCTOInformation/types.ts
+++ b/src/redux/surveyCTOInformation/types.ts
@@ -1,5 +1,5 @@
 export type SurveyCTOForm = {
-  last_ingested_at?: string;
+  last_ingested_at?: Date | null;
   form_uid?: string;
   survey_uid?: string;
   scto_form_id: string;


### PR DESCRIPTION
## [SS-1956, Minor] - Updating timezone of time displayed on the assignments screen

## Ticket

Fixes: https://idinsight.atlassian.net/browse/SS-1956

## Description, Motivation and Context
The last updated at time displayed on the assignments screen is actually the time in the survey timezone. It was displayed as GMT earlier. This PR updates this time to be in the survey timezone. Also removing the assigning criteria link.

## How Has This Been Tested?
On local

## UI Changes
For IST timezone:
<img width="915" alt="Screenshot 2024-11-26 at 1 58 28 PM" src="https://github.com/user-attachments/assets/714a6439-23c3-4965-b4b8-6e5fdca3d59e">

## To-do before merge
None

## Checklist:

This checklist is a useful reminder of small things that can easily be forgotten.
Put an `x` in all the items that apply and remove any items that are not relevant to this PR.

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
~~- [ ] I have updated the automated tests (if applicable)~~
- [x] I have written [good commit messages][1]
~~- [ ] I have updated the README file (if applicable)~~
~~- [ ] I have updated affected documentation (if applicable)~~

[SS-1956]: https://idinsight.atlassian.net/browse/SS-1956?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ