### PR TITLE
[SS-1986] Add duplicate button in DQ checks

### DIFF
--- a/src/modules/DQ/DQChecks/DQCheckGroup1.tsx
+++ b/src/modules/DQ/DQChecks/DQCheckGroup1.tsx
@@ -209,6 +209,18 @@ function DQCheckGroup1({ surveyUID, formUID, typeID }: IDQCheckGroup1Props) {
     showAddManualDrawer();
   };
 
+  const handleDuplicate = () => {
+    const selectedCheck = selectedVariableRows[0];
+    const duplicateData = {
+      ...selectedCheck,
+      questionName: "",
+      dqCheckUID: null,
+    };
+
+    showAddManualDrawer();
+    setDrawerData(duplicateData);
+  };
+
   const handleMarkActiveAction = () => {
     const selectedChecks = selectedVariableRows
       .filter((row: any) => !row.isDeleted)
@@ -728,8 +740,8 @@ function DQCheckGroup1({ surveyUID, formUID, typeID }: IDQCheckGroup1Props) {
           )}
           {mode === "selected" && (
             <>
-              <div style={{ display: "flex" }}>
-                <div style={{ marginTop: 16 }}>
+              <div style={{ display: "flex", marginTop: 24 }}>
+                <div>
                   <Tag
                     color="#F6FFED"
                     style={{ color: "#52C41A", borderColor: "#B7EB8F" }}
@@ -755,13 +767,21 @@ function DQCheckGroup1({ surveyUID, formUID, typeID }: IDQCheckGroup1Props) {
                     Add
                   </Button>
                   {selectedVariableRows.length === 1 && (
-                    <Button
-                      type="primary"
-                      style={{ marginLeft: 16 }}
-                      onClick={handleEditCheck}
-                    >
-                      Edit
-                    </Button>
+                    <>
+                      <Button
+                        type="primary"
+                        style={{ marginLeft: 16 }}
+                        onClick={handleEditCheck}
+                      >
+                        Edit
+                      </Button>
+                      <Button
+                        style={{ marginLeft: 16 }}
+                        onClick={handleDuplicate}
+                      >
+                        Duplicate
+                      </Button>
+                    </>
                   )}
                   {selectedVariableRows.length > 0 && (
                     <>


### PR DESCRIPTION
## [SS-1986] Add duplicate button in DQ checks

## Ticket

Fixes: https://idinsight.atlassian.net/browse/SS-1986

## Description, Motivation and Context
Adding a button to duplicate the check.

## How Has This Been Tested?
Locally at http://localhost:3000/module-configuration/dq-checks/178/48/edit/4?mode=selected

## UI Changes
<img width="1438" alt="Screenshot 2024-12-12 at 2 58 57 PM" src="https://github.com/user-attachments/assets/bf4203e4-8a43-4d2a-b475-46d37f23f6b6" />


## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have written [good commit messages][1]

[SS-1986]: https://idinsight.atlassian.net/browse/SS-1986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ