### PR TITLE
[MINOR Fix] - Updating version of the deploy action

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -82,7 +82,7 @@ jobs:
             sed -i 's#\\"##g' ./.github/workflows/appspecfinal.json  
 
       - name: ECS task deployment using CodeDeploy
-        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
         env:
           ACTIONS_STEP_DEBUG: true #enable step debug logging
         with:
@@ -166,7 +166,7 @@ jobs:
             sed -i 's#\\"##g' ./.github/workflows/appspecfinal.json  
 
       - name: ECS task deployment using CodeDeploy
-        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
         env:
           ACTIONS_STEP_DEBUG: true #enable step debug logging
         with:


### PR DESCRIPTION
## [MINOR Fix] - Updating version of the deploy action

## Ticket

Not created

## Description, Motivation and Context

GA [workflow](https://github.com/IDinsight/surveystream_react_app/actions/runs/12670199968/job/35309351278) for release is failing with error: `Error: Failed to register task definition in ECS: Unexpected key 'enableFaultInjection' found in params`. The recommended solution as per [this link](https://github.com/aws-actions/amazon-ecs-deploy-task-definition/issues/701) is to migrate to V2.

## How Has This Been Tested?
Not tested. We can test by moving this to staging.

## UI Changes
None

## To-do before merge
None

## Checklist:

This checklist is a useful reminder of small things that can easily be forgotten.
Put an `x` in all the items that apply and remove any items that are not relevant to this PR.

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- ~~[ ] I have updated the automated tests (if applicable)~~
- ~~[ ] I have written [good commit messages][1]~~
- ~~[ ] I have updated the README file (if applicable)~~
- ~~[ ] I have updated affected documentation (if applicable)~~