### PR TITLE
[MINOR] - Fixing filter operator typo, updating incorrect copy on protocol checks

### DIFF
--- a/src/modules/DQ/DQChecks/DQCheckGroup3.tsx
+++ b/src/modules/DQ/DQChecks/DQCheckGroup3.tsx
@@ -461,7 +461,7 @@ function DQCheckGroup3({ surveyUID, formUID, typeID }: IDQCheckGroup3Props) {
             {typeID === "7" &&
               "Checks that a variable value in the main form matches the value of the same variable recorded in a data quality form (backcheck/ audioaudit/ spotcheck form). Kindly note that the variable name in the two forms have to be the same."}
             {typeID === "8" &&
-              "Checks if a protocol has been violated. For all protocol questions, calculations assume that the value 1 indicates a violation, while the value 0 indicates no violation."}
+              "Checks if a protocol has been violated. For all protocol questions, calculations assume that the value 0 indicates a violation, while the value 1 indicates no violation."}
             {typeID === "9" &&
               "Averages the spotcheck scores recorded in data quality forms. Multiple variables can be aggregated to one score using the 'Score name' input."}
           </p>

--- a/src/modules/DQ/DQChecks/DQChecksFilter.tsx
+++ b/src/modules/DQ/DQChecks/DQChecksFilter.tsx
@@ -26,7 +26,7 @@ function DQChecksFilter({
     "Does not contain",
     "Is empty",
     "Is not empty",
-    "Greather than",
+    "Greater than",
     "Smaller than",
   ];
 


### PR DESCRIPTION
## [MINOR] - Fixing filter operator typo, updating incorrect copy on protocol checks

## Ticket

Linked to: https://idinsight.atlassian.net/browse/SS-1895

## Description, Motivation and Context

Fixing a typo in the filter operator spelling. In addition, as per calculations our protocol violations 0 is considered a violation - fixing the copy on the check to avoid confusion.

## How Has This Been Tested?
On local

## To-do before merge

- [x] Ensure the linked [backend PR](https://github.com/IDinsight/surveystream_flask_api/pull/276) is also merged

## Checklist:

This checklist is a useful reminder of small things that can easily be forgotten.
Put an `x` in all the items that apply and remove any items that are not relevant to this PR.

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
~~- [x] I have updated the automated tests (if applicable)~~
- [x] I have written [good commit messages][1]
~~- [x] I have updated the README file (if applicable)~~
~~- [x] I have updated affected documentation (if applicable)~~