### PR TITLE
[SS-2011] Fix DQ table refresh lag

### DIFF
--- a/src/components/DQCheckDrawer/DQCheckDrawer.tsx
+++ b/src/components/DQCheckDrawer/DQCheckDrawer.tsx
@@ -135,6 +135,7 @@ function DQCheckDrawer({
             <Form.Item
               label="Select variable"
               tooltip="Choose variable from SCTO question list"
+              required
             />
           </Col>
           <Col span={12}>
@@ -156,6 +157,7 @@ function DQCheckDrawer({
             <Form.Item
               label="Check values:"
               tooltip="Value that is considered for checks"
+              required
             />
           </Col>
           <Col span={12}>

--- a/src/components/DQCheckDrawer/DQCheckDrawerGroup2.tsx
+++ b/src/components/DQCheckDrawer/DQCheckDrawerGroup2.tsx
@@ -170,6 +170,7 @@ function DQCheckDrawer({
             <Form.Item
               label="Select variable"
               tooltip="Choose variable from SCTO question list"
+              required
             />
           </Col>
           <Col span={12}>
@@ -282,6 +283,7 @@ function DQCheckDrawer({
                 <Form.Item
                   label="Measure:"
                   tooltip="Unit of measurement for the variable"
+                  required
                 />
               </Col>
               <Col span={12}>
@@ -309,6 +311,7 @@ function DQCheckDrawer({
                 <Form.Item
                   label="Multipler / Value:"
                   tooltip="Value that is considered for checks"
+                  required
                 />
               </Col>
               <Col span={12}>

--- a/src/components/DQCheckDrawer/DQCheckDrawerGroup3.tsx
+++ b/src/components/DQCheckDrawer/DQCheckDrawerGroup3.tsx
@@ -218,6 +218,7 @@ function DQCheckDrawerGroup3({
             <Form.Item
               label="Select data quality form:"
               tooltip="Form on which the check will run."
+              required
             />
           </Col>
           <Col span={12}>
@@ -244,6 +245,7 @@ function DQCheckDrawerGroup3({
                   ? "Select from the list of common questions in the parent and selected DQ form. Mismatch checks require the question name to be same in both forms."
                   : "Select from the list of questions in the selected DQ form."
               }`}
+              required
             />
           </Col>
           <Col span={12}>

--- a/src/components/DQCheckDrawer/DQCheckDrawerGroup4.tsx
+++ b/src/components/DQCheckDrawer/DQCheckDrawerGroup4.tsx
@@ -146,6 +146,7 @@ function DQCheckDrawer4({
             <Form.Item
               label="Select type:"
               tooltip="Type of GPS check. Ex. Point to Point or Point to Shape"
+              required
             />
           </Col>
           <Col span={12}>
@@ -166,6 +167,7 @@ function DQCheckDrawer4({
             <Form.Item
               label="Select variable"
               tooltip="Choose variable from SCTO question list"
+              required
             />
           </Col>
           <Col span={12}>
@@ -188,6 +190,7 @@ function DQCheckDrawer4({
               <Form.Item
                 label="Expected GPS variable:"
                 tooltip="Value that is considered for checks"
+                required
               />
             </Col>
             <Col span={12}>
@@ -212,6 +215,7 @@ function DQCheckDrawer4({
               <Form.Item
                 label="Grid ID variable:"
                 tooltip="Value that is considered for checks"
+                required
               />
             </Col>
             <Col span={12}>
@@ -234,6 +238,7 @@ function DQCheckDrawer4({
             <Form.Item
               label="Threshold distance (m):"
               tooltip="Threshold to check value within"
+              required
             />
           </Col>
           <Col span={12}>

--- a/src/modules/DQ/DQChecks/DQCheckGroup1.tsx
+++ b/src/modules/DQ/DQChecks/DQCheckGroup1.tsx
@@ -239,13 +239,16 @@ function DQCheckGroup1({ surveyUID, formUID, typeID }: IDQCheckGroup1Props) {
 
     setLoading(true);
     activateDQChecks(formData).then((res: any) => {
-      setLoading(false);
       if (res?.data?.success) {
         message.success("DQ Check activated", 1, () => {
-          navigate(0);
+          loadDQChecks();
+          setDataLoading(true);
+          setSelectedVariableRows([]);
+          setLoading(false);
         });
       } else {
         message.error("Failed to activate DQ Checks");
+        setLoading(false);
       }
     });
   };
@@ -284,13 +287,16 @@ function DQCheckGroup1({ surveyUID, formUID, typeID }: IDQCheckGroup1Props) {
 
     setLoading(true);
     deactivateDQChecks(formData).then((res: any) => {
-      setLoading(false);
       if (res?.data?.success) {
         message.success("DQ Check deactivated", 1, () => {
-          navigate(0);
+          loadDQChecks();
+          setDataLoading(true);
+          setSelectedVariableRows([]);
+          setLoading(false);
         });
       } else {
         message.error("Failed to deactivate DQ Checks");
+        setLoading(false);
       }
     });
   };
@@ -308,13 +314,16 @@ function DQCheckGroup1({ surveyUID, formUID, typeID }: IDQCheckGroup1Props) {
 
     setLoading(true);
     deleteDQChecks(formData).then((res: any) => {
-      setLoading(false);
       if (res?.data?.success) {
         message.success("DQ Checks deleted", 1, () => {
-          navigate(0);
+          loadDQChecks();
+          setDataLoading(true);
+          setSelectedVariableRows([]);
+          setLoading(false);
         });
       } else {
         message.error("Failed to delete DQ Checks");
+        setLoading(false);
       }
     });
   };
@@ -628,7 +637,7 @@ function DQCheckGroup1({ surveyUID, formUID, typeID }: IDQCheckGroup1Props) {
                 />
               </div>
               <Row>
-                <Col span={4}>
+                <Col span={5}>
                   <Form.Item
                     label={`Value is ${
                       typeID === "4"
@@ -638,6 +647,7 @@ function DQCheckGroup1({ surveyUID, formUID, typeID }: IDQCheckGroup1Props) {
                         : "refusal"
                     } if value is:`}
                     tooltip="Value that is considered for checks"
+                    required
                   />
                 </Col>
                 <Col span={6}>
@@ -672,7 +682,7 @@ function DQCheckGroup1({ surveyUID, formUID, typeID }: IDQCheckGroup1Props) {
                 </Col>
               </Row>
               <Row>
-                <Col span={4}>
+                <Col span={5}>
                   <Form.Item
                     label="Flag description:"
                     tooltip="Short description of the flag that will be included in the outputs"
@@ -802,14 +812,24 @@ function DQCheckGroup1({ surveyUID, formUID, typeID }: IDQCheckGroup1Props) {
                     <CustomBtn
                       style={{ marginLeft: 16 }}
                       onClick={handleMarkActive}
-                      disabled={selectedVariableRows.length === 0}
+                      disabled={
+                        selectedVariableRows.length === 0 ||
+                        !selectedVariableRows.some(
+                          (row: any) => row.status === "Inactive"
+                        )
+                      }
                     >
                       Mark active
                     </CustomBtn>
                     <Button
                       style={{ marginLeft: 16 }}
                       onClick={handleMarkInactive}
-                      disabled={selectedVariableRows.length === 0}
+                      disabled={
+                        selectedVariableRows.length === 0 ||
+                        !selectedVariableRows.some(
+                          (row: any) => row.status === "Active"
+                        )
+                      }
                     >
                       Mark inactive
                     </Button>

--- a/src/modules/DQ/DQChecks/DQCheckGroup2.tsx
+++ b/src/modules/DQ/DQChecks/DQCheckGroup2.tsx
@@ -214,13 +214,16 @@ function DQCheckGroup2({ surveyUID, formUID, typeID }: IDQCheckGroup1Props) {
 
     setLoading(true);
     activateDQChecks(formData).then((res: any) => {
-      setLoading(false);
       if (res?.data?.success) {
         message.success("DQ Check activated", 1, () => {
-          navigate(0);
+          loadDQChecks();
+          setDataLoading(true);
+          setSelectedVariableRows([]);
+          setLoading(false);
         });
       } else {
         message.error("Failed to activate DQ Checks");
+        setLoading(false);
       }
     });
   };
@@ -259,13 +262,16 @@ function DQCheckGroup2({ surveyUID, formUID, typeID }: IDQCheckGroup1Props) {
 
     setLoading(true);
     deactivateDQChecks(formData).then((res: any) => {
-      setLoading(false);
       if (res?.data?.success) {
         message.success("DQ Check deactivated", 1, () => {
-          navigate(0);
+          loadDQChecks();
+          setDataLoading(true);
+          setSelectedVariableRows([]);
+          setLoading(false);
         });
       } else {
         message.error("Failed to deactivate DQ Checks");
+        setLoading(false);
       }
     });
   };
@@ -283,13 +289,16 @@ function DQCheckGroup2({ surveyUID, formUID, typeID }: IDQCheckGroup1Props) {
 
     setLoading(true);
     deleteDQChecks(formData).then((res: any) => {
-      setLoading(false);
       if (res?.data?.success) {
         message.success("DQ Checks deleted", 1, () => {
-          navigate(0);
+          loadDQChecks();
+          setDataLoading(true);
+          setSelectedVariableRows([]);
+          setLoading(false);
         });
       } else {
         message.error("Failed to delete DQ Checks");
+        setLoading(false);
       }
     });
   };
@@ -511,14 +520,24 @@ function DQCheckGroup2({ surveyUID, formUID, typeID }: IDQCheckGroup1Props) {
                   <CustomBtn
                     style={{ marginLeft: 16 }}
                     onClick={handleMarkActive}
-                    disabled={selectedVariableRows.length === 0}
+                    disabled={
+                      selectedVariableRows.length === 0 ||
+                      !selectedVariableRows.some(
+                        (row: any) => row.status === "Inactive"
+                      )
+                    }
                   >
                     Mark active
                   </CustomBtn>
                   <Button
                     style={{ marginLeft: 16 }}
                     onClick={handleMarkInactive}
-                    disabled={selectedVariableRows.length === 0}
+                    disabled={
+                      selectedVariableRows.length === 0 ||
+                      !selectedVariableRows.some(
+                        (row: any) => row.status === "Active"
+                      )
+                    }
                   >
                     Mark inactive
                   </Button>

--- a/src/modules/DQ/DQChecks/DQCheckGroup3.tsx
+++ b/src/modules/DQ/DQChecks/DQCheckGroup3.tsx
@@ -208,13 +208,16 @@ function DQCheckGroup3({ surveyUID, formUID, typeID }: IDQCheckGroup3Props) {
 
     setLoading(true);
     activateDQChecks(formData).then((res: any) => {
-      setLoading(false);
       if (res?.data?.success) {
         message.success("DQ Check activated", 1, () => {
-          navigate(0);
+          loadDQChecks();
+          setDataLoading(true);
+          setSelectedVariableRows([]);
+          setLoading(false);
         });
       } else {
         message.error("Failed to activate DQ Checks");
+        setLoading(false);
       }
     });
   };
@@ -253,13 +256,16 @@ function DQCheckGroup3({ surveyUID, formUID, typeID }: IDQCheckGroup3Props) {
 
     setLoading(true);
     deactivateDQChecks(formData).then((res: any) => {
-      setLoading(false);
       if (res?.data?.success) {
         message.success("DQ Check deactivated", 1, () => {
-          navigate(0);
+          loadDQChecks();
+          setDataLoading(true);
+          setSelectedVariableRows([]);
+          setLoading(false);
         });
       } else {
         message.error("Failed to deactivate DQ Checks");
+        setLoading(false);
       }
     });
   };
@@ -277,13 +283,16 @@ function DQCheckGroup3({ surveyUID, formUID, typeID }: IDQCheckGroup3Props) {
 
     setLoading(true);
     deleteDQChecks(formData).then((res: any) => {
-      setLoading(false);
       if (res?.data?.success) {
         message.success("DQ Checks deleted", 1, () => {
-          navigate(0);
+          loadDQChecks();
+          setDataLoading(true);
+          setSelectedVariableRows([]);
+          setLoading(false);
         });
       } else {
         message.error("Failed to delete DQ Checks");
+        setLoading(false);
       }
     });
   };
@@ -518,14 +527,24 @@ function DQCheckGroup3({ surveyUID, formUID, typeID }: IDQCheckGroup3Props) {
                 <CustomBtn
                   style={{ marginLeft: 16 }}
                   onClick={handleMarkActive}
-                  disabled={selectedVariableRows.length === 0}
+                  disabled={
+                    selectedVariableRows.length === 0 ||
+                    !selectedVariableRows.some(
+                      (row: any) => row.status === "Inactive"
+                    )
+                  }
                 >
                   Mark active
                 </CustomBtn>
                 <Button
                   style={{ marginLeft: 16 }}
                   onClick={handleMarkInactive}
-                  disabled={selectedVariableRows.length === 0}
+                  disabled={
+                    selectedVariableRows.length === 0 ||
+                    !selectedVariableRows.some(
+                      (row: any) => row.status === "Active"
+                    )
+                  }
                 >
                   Mark inactive
                 </Button>

--- a/src/modules/DQ/DQChecks/DQCheckGroup4.tsx
+++ b/src/modules/DQ/DQChecks/DQCheckGroup4.tsx
@@ -179,13 +179,16 @@ function DQCheckGroup4({ surveyUID, formUID, typeID }: IDQCheckGroup1Props) {
 
     setLoading(true);
     activateDQChecks(formData).then((res: any) => {
-      setLoading(false);
       if (res?.data?.success) {
         message.success("DQ Check activated", 1, () => {
-          navigate(0);
+          loadDQChecks();
+          setDataLoading(true);
+          setSelectedVariableRows([]);
+          setLoading(false);
         });
       } else {
         message.error("Failed to activate DQ Checks");
+        setLoading(false);
       }
     });
   };
@@ -224,13 +227,16 @@ function DQCheckGroup4({ surveyUID, formUID, typeID }: IDQCheckGroup1Props) {
 
     setLoading(true);
     deactivateDQChecks(formData).then((res: any) => {
-      setLoading(false);
       if (res?.data?.success) {
         message.success("DQ Check deactivated", 1, () => {
-          navigate(0);
+          loadDQChecks();
+          setDataLoading(true);
+          setSelectedVariableRows([]);
+          setLoading(false);
         });
       } else {
         message.error("Failed to deactivate DQ Checks");
+        setLoading(false);
       }
     });
   };
@@ -248,13 +254,16 @@ function DQCheckGroup4({ surveyUID, formUID, typeID }: IDQCheckGroup1Props) {
 
     setLoading(true);
     deleteDQChecks(formData).then((res: any) => {
-      setLoading(false);
       if (res?.data?.success) {
         message.success("DQ Checks deleted", 1, () => {
-          navigate(0);
+          loadDQChecks();
+          setDataLoading(true);
+          setSelectedVariableRows([]);
+          setLoading(false);
         });
       } else {
         message.error("Failed to delete DQ Checks");
+        setLoading(false);
       }
     });
   };
@@ -442,14 +451,24 @@ function DQCheckGroup4({ surveyUID, formUID, typeID }: IDQCheckGroup1Props) {
                   <CustomBtn
                     style={{ marginLeft: 16 }}
                     onClick={handleMarkActive}
-                    disabled={selectedVariableRows.length === 0}
+                    disabled={
+                      selectedVariableRows.length === 0 ||
+                      !selectedVariableRows.some(
+                        (row: any) => row.status === "Inactive"
+                      )
+                    }
                   >
                     Mark active
                   </CustomBtn>
                   <Button
                     style={{ marginLeft: 16 }}
                     onClick={handleMarkInactive}
-                    disabled={selectedVariableRows.length === 0}
+                    disabled={
+                      selectedVariableRows.length === 0 ||
+                      !selectedVariableRows.some(
+                        (row: any) => row.status === "Active"
+                      )
+                    }
                   >
                     Mark inactive
                   </Button>

--- a/src/modules/DQ/DQChecks/DQChecksAssertion.tsx
+++ b/src/modules/DQ/DQChecks/DQChecksAssertion.tsx
@@ -1,6 +1,7 @@
 import { Col, Row, Tag, Input, Button } from "antd";
 import {
   DeleteFilled,
+  MinusSquareFilled,
   PlusCircleFilled,
   PlusSquareFilled,
 } from "@ant-design/icons";
@@ -160,7 +161,7 @@ function DQChecksAssertion({
             </Button>
             <Button
               type="link"
-              icon={<PlusSquareFilled />}
+              icon={<MinusSquareFilled />}
               onClick={() => handleRemoveAssertionGroup(groupIndex)}
               danger
             >

--- a/src/modules/DQ/DQChecks/DQChecksFilter.tsx
+++ b/src/modules/DQ/DQChecks/DQChecksFilter.tsx
@@ -1,6 +1,7 @@
 import { Col, Row, Select, Tag, DatePicker, Input, Button } from "antd";
 import {
   DeleteFilled,
+  MinusSquareFilled,
   PlusCircleFilled,
   PlusSquareFilled,
 } from "@ant-design/icons";
@@ -242,7 +243,7 @@ function DQChecksFilter({
             </Button>
             <Button
               type="link"
-              icon={<PlusSquareFilled />}
+              icon={<MinusSquareFilled />}
               onClick={() => handleRemoveFilterGroup(groupIndex)}
               danger
             >


### PR DESCRIPTION
## [SS-2011] Fix DQ table refresh lag

## Ticket

Fixes: https://idinsight.atlassian.net/browse/SS-2011

## Description, Motivation and Context
Fixing the lag issue in the DQ table

Also fixing the following:
1. Enable “Mark Active” button only when an inactive row is selected, and vice-versa for Inactive.
2. Add asterisk all throughout
3. 'Delete the group' icon to be a '-' icon

## How Has This Been Tested?
Locally at http://localhost:3000/module-configuration/dq-checks/178

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have written [good commit messages][1]

[SS-2011]: https://idinsight.atlassian.net/browse/SS-2011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ