### PR TITLE
[SS-2031] - Minor change to show repeat group variables in gps checks

### DIFF
--- a/src/modules/DQ/DQChecks/DQCheckGroup4.tsx
+++ b/src/modules/DQ/DQChecks/DQCheckGroup4.tsx
@@ -77,12 +77,20 @@ function DQCheckGroup4({ surveyUID, formUID, typeID }: IDQCheckGroup1Props) {
       dataIndex: "gridIDVariable",
       key: "gridIDVariable",
       sorter: (a: any, b: any) => a.questionName.localeCompare(b.questionName),
+      render: (gridIDVariable: any, record: any) =>
+        gridIDVariable
+          ? gridIDVariable + (record.gridIDVariableIsRepeatGroup ? "_*" : "")
+          : "",
     },
     {
       title: "Expected GPS variable",
       dataIndex: "gpsVariable",
       key: "gpsVariable",
       sorter: (a: any, b: any) => a.questionName.localeCompare(b.questionName),
+      render: (gpsVariable: any, record: any) =>
+        gpsVariable
+          ? gpsVariable + (record.gpsVariableIsRepeatGroup ? "_*" : "")
+          : "",
     },
     {
       title: "Threshold distance (m)",
@@ -119,13 +127,19 @@ function DQCheckGroup4({ surveyUID, formUID, typeID }: IDQCheckGroup1Props) {
     questionName: check.question_name,
     gpsType: check.check_components.gps_type,
     threshold: check.check_components.threshold,
-    gpsVariable: check.check_components.gps_variable,
-    gridIDVariable: check.check_components.grid_id,
+    gpsVariable: check.check_components.gps_variable?.question_name,
+    gpsVariableIsRepeatGroup:
+      check.check_components.gps_variable?.is_repeat_group,
+    gridIDVariable: check.check_components.grid_id?.question_name,
+    gridIDVariableIsRepeatGroup:
+      check.check_components.grid_id?.is_repeat_group,
     status: check.active ? "Active" : "Inactive",
     isDeleted:
       check.note === "Question not found in form definition" ||
       check.note === "Question not found in DQ form definition" ||
-      check.note === "Filter question not found in form definition",
+      check.note === "Filter question not found in form definition" ||
+      check.note === "GPS variable not found in form definition" ||
+      check.note === "Grid ID not found in form definition",
     isRepeatGroup: check.is_repeat_group,
   }));
 


### PR DESCRIPTION
## [SS-2031] - Minor change to show repeat group variables in gps checks

## Ticket

Fixes: https://idinsight.atlassian.net/browse/SS-2031

## Description, Motivation and Context

Minor update on GPS checks screen to show repeat group variables with a `_*` on the table and show inactive if the note says grid id/ gps variable is missing

## How Has This Been Tested?
On local. To be tested with backend change [here](https://github.com/IDinsight/surveystream_flask_api/pull/291)

## To-do before merge
- [x] Ensure [backend change](https://github.com/IDinsight/surveystream_flask_api/pull/291) is merged

## Checklist:

This checklist is a useful reminder of small things that can easily be forgotten.
Put an `x` in all the items that apply and remove any items that are not relevant to this PR.

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- ~~[ ] I have updated the automated tests (if applicable)~~
- [x] I have written [good commit messages][1]
- ~~[ ] I have updated the README file (if applicable)~~
- ~~[ ] I have updated affected documentation (if applicable)~~

[SS-2031]: https://idinsight.atlassian.net/browse/SS-2031?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ