### PR TITLE
[SS-2050] Add encryption form options for DQ and Admin form

### DIFF
--- a/src/modules/AdminForm/AdminFormManage.tsx
+++ b/src/modules/AdminForm/AdminFormManage.tsx
@@ -8,7 +8,7 @@ import { HeaderContainer } from "../../shared/Nav.styled";
 import { BodyContainer, CustomBtn, FormItemLabel } from "./AdminForm.styled";
 import { getSurveyCTOForm } from "../../redux/surveyCTOInformation/surveyCTOInformationActions";
 import { RootState } from "../../redux/store";
-import { Button, Col, Input, Row, Select, message } from "antd";
+import { Button, Checkbox, Col, Input, Row, Select, message } from "antd";
 import {
   createAdminForm,
   getAdminForm,
@@ -149,7 +149,6 @@ function AdminFormManage() {
         ...prev,
         tz_name: surveyCTOForm?.tz_name,
         scto_server_name: surveyCTOForm?.scto_server_name,
-        encryption_key_shared: surveyCTOForm?.encryption_key_shared,
         server_access_role_granted: surveyCTOForm?.server_access_role_granted,
         server_access_allowed: surveyCTOForm?.server_access_allowed,
       }));
@@ -251,6 +250,26 @@ function AdminFormManage() {
                 />
               </Col>
             </Row>
+            <Row align={"middle"} style={{ marginBottom: 6 }}>
+              <Col>
+                <Checkbox
+                  checked={formFieldsData?.encryption_key_shared}
+                  onChange={(e) => {
+                    setFormFieldsData((prev: any) => ({
+                      ...prev,
+                      encryption_key_shared: e.target.checked,
+                    }));
+                  }}
+                >
+                  The form is encrypted. If yes, please share the key with{" "}
+                  <a href="mail:surveystream.devs@idinsight.org">
+                    surveystream.devs@idinsight.org
+                  </a>{" "}
+                  via FlowCrypt/Nordpass.
+                </Checkbox>
+              </Col>
+            </Row>
+
             <div>
               <Button
                 style={{ marginTop: 24, marginRight: 24 }}

--- a/src/modules/DQ/DQForm/DQFormManage.tsx
+++ b/src/modules/DQ/DQForm/DQFormManage.tsx
@@ -8,7 +8,7 @@ import { HeaderContainer } from "../../../shared/Nav.styled";
 import { CustomBtn, DQFormWrapper, FormItemLabel } from "./DQForm.styled";
 import { getSurveyCTOForm } from "../../../redux/surveyCTOInformation/surveyCTOInformationActions";
 import { RootState } from "../../../redux/store";
-import { Button, Col, Input, Row, Select, message } from "antd";
+import { Button, Checkbox, Col, Input, Row, Select, message } from "antd";
 import {
   createDQForm,
   getDQForm,
@@ -149,7 +149,6 @@ function DQFormManage() {
           ...prev,
           tz_name: surveyCTOForm?.tz_name,
           scto_server_name: surveyCTOForm?.scto_server_name,
-          encryption_key_shared: surveyCTOForm?.encryption_key_shared,
           server_access_role_granted: surveyCTOForm?.server_access_role_granted,
           server_access_allowed: surveyCTOForm?.server_access_allowed,
         }));
@@ -280,6 +279,25 @@ function DQFormManage() {
                       }));
                     }}
                   />
+                </Col>
+              </Row>
+              <Row align={"middle"} style={{ marginBottom: 6 }}>
+                <Col>
+                  <Checkbox
+                    checked={formFieldsData?.encryption_key_shared}
+                    onChange={(e) => {
+                      setFormFieldsData((prev: any) => ({
+                        ...prev,
+                        encryption_key_shared: e.target.checked,
+                      }));
+                    }}
+                  >
+                    The form is encrypted. If yes, please share the key with{" "}
+                    <a href="mail:surveystream.devs@idinsight.org">
+                      surveystream.devs@idinsight.org
+                    </a>{" "}
+                    via FlowCrypt/Nordpass.
+                  </Checkbox>
                 </Col>
               </Row>
               <div>


### PR DESCRIPTION
## [SS-2050] Add encryption form options for DQ and Admin form


## Ticket

Fixes: https://idinsight.atlassian.net/browse/SS-2050

## Description, Motivation and Context

Add encryption forms for DQ and admin forms.

## How Has This Been Tested?
Local

## UI Changes

![image](https://github.com/user-attachments/assets/90c06b51-9b42-4352-86c0-ad6ca4345513)
![image](https://github.com/user-attachments/assets/24be18f8-8357-41de-8d9e-5d93c12ca1e6)

## Checklist:

This checklist is a useful reminder of small things that can easily be forgotten.
Put an `x` in all the items that apply and remove any items that are not relevant to this PR.

- [ ] My code follows the style guidelines of this project
- [ ] I have reviewed my own code to ensure good quality
- [ ] I have tested the functionality of my code to ensure it works as intended
- [ ] I have resolved merge conflicts
- [ ] I have updated the automated tests (if applicable)
- [ ] I have written [good commit messages][1]
- [ ] I have updated the README file (if applicable)
- [ ] I have updated affected documentation (if applicable)

[SS-2050]: https://idinsight.atlassian.net/browse/SS-2050?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ