### PR TITLE
SS-2047: Duplicate survey status or survey status label

### DIFF
--- a/src/modules/SurveyInformation/SurveyStatusMapping/SurveyStatusMapping.tsx
+++ b/src/modules/SurveyInformation/SurveyStatusMapping/SurveyStatusMapping.tsx
@@ -164,7 +164,6 @@ function SurveyStatusMapping() {
     setEditingData(rowData);
     setEditingMode("edit");
   };
-
   const onAddMapping = () => {
     if (!sctoForm.form_uid) return;
 
@@ -183,7 +182,7 @@ function SurveyStatusMapping() {
     }
 
     // Check if survey status and survey status label already exists
-    targetStatusMapping.forEach((ele: any) => {
+    for (const ele of targetStatusMapping) {
       if (ele.survey_status === parseInt(editingData.survey_status)) {
         message.error(
           "Survey status already exists, please add unique survey status!"
@@ -200,7 +199,7 @@ function SurveyStatusMapping() {
         );
         return;
       }
-    });
+    }
 
     dispatch(
       updateTargetStatusMapping({
@@ -208,7 +207,7 @@ function SurveyStatusMapping() {
         data: [...targetStatusMapping, editingData],
       })
     ).then((res) => {
-      if (res.payload.data.success) {
+      if (res.payload.data && res.payload.data.success === true) {
         message.success("Mapping added successfully!");
         setEditingMode(null);
         setSelectedRowKeys([]);


### PR DESCRIPTION
## SS-2047: Duplicate survey status or survey status label

## Ticket

Fixes: https://idinsight.atlassian.net/browse/SS-2047

## Description, Motivation and Context

When adding a new survey status with a duplicate survey status or survey status label the code was dispatching the put request. 
Fixed the error by using a for loop instead of for each and added a validation to check if put request has any response or not.

## How Has This Been Tested?
Local

## Checklist:

This checklist is a useful reminder of small things that can easily be forgotten.
Put an `x` in all the items that apply and remove any items that are not relevant to this PR.

- [ ] My code follows the style guidelines of this project
- [ ] I have reviewed my own code to ensure good quality
- [ ] I have tested the functionality of my code to ensure it works as intended
- [ ] I have resolved merge conflicts
- [ ] I have written [good commit messages][1]