### PR TITLE
Media file: UI Changes

### DIFF
--- a/src/modules/MediaAudits/MediaAuditsManage.tsx
+++ b/src/modules/MediaAudits/MediaAuditsManage.tsx
@@ -55,7 +55,7 @@ function MediaAuditsManage() {
 
   const [isQuestionLoading, setIsQuestionLoading] = useState(false);
   const [questions, setQuestions] = useState<any[]>([]);
-  const [questionWithRepeatGroup, setQuestionWithRepeatGroup] = useState<any[]>(
+  const [questionWithMediaFields, setQuestionWithMediaFields] = useState<any[]>(
     []
   );
   const [mappingOPtions, setMappingOptions] = useState<any[]>([]);
@@ -124,21 +124,28 @@ function MediaAuditsManage() {
         message.error(errorMsg);
       }
       if (repeatGroupRes.payload?.questions) {
-        const repeatGroupQuestions: any = [];
+        const mediaTypeQuestions: any = [];
         repeatGroupRes.payload?.questions.forEach((question: any) => {
+          if (
+            !["image", "audio", "video", "file", "audio_audit"].includes(
+              question.question_type
+            )
+          ) {
+            return;
+          }
           if (question.is_repeat_group) {
-            repeatGroupQuestions.push({
+            mediaTypeQuestions.push({
               label: question.question_name + "_*",
               value: question.question_name,
             });
           } else {
-            repeatGroupQuestions.push({
+            mediaTypeQuestions.push({
               label: question.question_name,
               value: question.question_name,
             });
           }
         });
-        setQuestionWithRepeatGroup(repeatGroupQuestions);
+        setQuestionWithMediaFields(mediaTypeQuestions);
       }
       // Only fetch mapping criteria if it's not an admin form
       if (!adminForms.some((form: any) => form.form_uid === formUid)) {
@@ -481,7 +488,7 @@ function MediaAuditsManage() {
                 <Select
                   style={{ width: "100%" }}
                   placeholder="Multi select"
-                  options={questionWithRepeatGroup.filter(
+                  options={questionWithMediaFields.filter(
                     (q) => !formFieldsData?.scto_fields?.includes(q.value)
                   )}
                   mode="multiple"


### PR DESCRIPTION
## Media file: UI Changes

## Description, Motivation and Context

Minor UI changes for media files config:

1. Disabled media fields and format fields if source is exotel
2. Added _* for repeat group variables
3. Added validations on mapping at [backend](https://github.com/IDinsight/surveystream_flask_api/pull/305)

## How Has This Been Tested?
Local

## UI Changes
![Screenshot 2025-05-05 at 15 43 41](https://github.com/user-attachments/assets/bee0cc5f-4a20-4e64-9a8d-4568ba8c4156)

![Screenshot 2025-05-05 at 15 43 46](https://github.com/user-attachments/assets/3e4e725b-90c1-4827-a20a-1ee79d3adeae)

![Screenshot 2025-05-05 at 15 44 00](https://github.com/user-attachments/assets/991182f6-b8ac-4f71-a81b-197cf05c1f49)

## To-do before merge


- [ ] Ensure PR https://github.com/IDinsight/surveystream_flask_api/pull/305 is merged

## Checklist:

This checklist is a useful reminder of small things that can easily be forgotten.
Put an `x` in all the items that apply and remove any items that are not relevant to this PR.

- [ ] My code follows the style guidelines of this project
- [ ] I have reviewed my own code to ensure good quality
- [ ] I have tested the functionality of my code to ensure it works as intended
- [ ] I have resolved merge conflicts
- [ ] I have updated the automated tests (if applicable)
- [ ] I have written [good commit messages][1]
- [ ] I have updated the README file (if applicable)
- [ ] I have updated affected documentation (if applicable)