### PR TITLE
[SS-2040] - DQ selection on multi-select questions

### DIFF
--- a/src/components/DQCheckDrawer/DQCheckDrawerGroup2.tsx
+++ b/src/components/DQCheckDrawer/DQCheckDrawerGroup2.tsx
@@ -179,10 +179,13 @@ function DQCheckDrawer({
               showSearch
               placeholder="Select variable"
               value={localData.variable_name}
-              options={questions.map((question: any) => ({
-                value: question.name,
-                label: question.label,
-              }))}
+              options={questions
+                // Remove multi-select questions since they are not applicable for outlier and constraint checks
+                .filter((question: any) => question.is_multi_select !== true)
+                .map((question: any) => ({
+                  value: question.name,
+                  label: question.label,
+                }))}
               onChange={(value) => handleFieldChange("variable_name", value)}
             />
           </Col>

--- a/src/components/DQCheckDrawer/DQCheckDrawerGroup3.tsx
+++ b/src/components/DQCheckDrawer/DQCheckDrawerGroup3.tsx
@@ -131,14 +131,22 @@ function DQCheckDrawerGroup3({
           if (res?.data?.success) {
             const formDefinition = res.data.data;
             if (formDefinition && formDefinition.questions) {
-              const questionNames = formDefinition.questions.map(
-                (question: any) => ({
-                  name: question.question_name,
-                  label:
-                    question.question_name +
-                    (question.is_repeat_group ? "_*" : ""),
-                })
+              // Filter to exclude repeat groups with select_multiple question types
+              const filteredQuestions = formDefinition.questions.filter(
+                (question: any) =>
+                  !(
+                    question.is_repeat_group &&
+                    question.question_type.startsWith("select_multiple")
+                  )
               );
+              const questionNames = filteredQuestions.map((question: any) => ({
+                name: question.question_name,
+                label:
+                  question.question_name +
+                  (question.is_repeat_group ? "_*" : ""),
+                is_multi_select:
+                  question.question_type.startsWith("select_multiple"),
+              }));
               setDqFormQuestions(questionNames);
             }
           }
@@ -163,7 +171,12 @@ function DQCheckDrawerGroup3({
         });
         setFinalQuestions(questions);
       } else {
-        setFinalQuestions(dqFormQuestions);
+        // for protocol violations and spotcheck scores, remove select multiple questions
+        const dqFormQuestionsFiltered = dqFormQuestions.filter(
+          (question: any) => question.is_multi_select !== true
+        );
+
+        setFinalQuestions(dqFormQuestionsFiltered);
       }
     } else {
       setFinalQuestions([]);

--- a/src/components/DQCheckDrawer/DQCheckDrawerGroup4.tsx
+++ b/src/components/DQCheckDrawer/DQCheckDrawerGroup4.tsx
@@ -176,10 +176,13 @@ function DQCheckDrawer4({
               showSearch
               placeholder="Select variable"
               value={localData.variable_name ?? null}
-              options={questions.map((question: any) => ({
-                value: question.name,
-                label: question.label,
-              }))}
+              options={questions
+                // Remove multi-select questions since they are not applicable for gps checks
+                .filter((question: any) => question.is_multi_select !== true)
+                .map((question: any) => ({
+                  value: question.name,
+                  label: question.label,
+                }))}
               onChange={(value) => handleFieldChange("variable_name", value)}
             />
           </Col>
@@ -199,10 +202,13 @@ function DQCheckDrawer4({
                 showSearch
                 placeholder="Select GPS variable"
                 value={localData.gps_variable}
-                options={questions.map((question: any) => ({
-                  value: question.name,
-                  label: question.label,
-                }))}
+                options={questions
+                  // Remove multi-select questions since they are not applicable for gps checks
+                  .filter((question: any) => question.is_multi_select !== true)
+                  .map((question: any) => ({
+                    value: question.name,
+                    label: question.label,
+                  }))}
                 onChange={(value) => handleFieldChange("gps_variable", value)}
               />
             </Col>
@@ -224,10 +230,13 @@ function DQCheckDrawer4({
                 showSearch
                 placeholder="Select GPS Grid ID variable"
                 value={localData.grid_id}
-                options={questions.map((question: any) => ({
-                  value: question.name,
-                  label: question.label,
-                }))}
+                options={questions
+                  // Remove multi-select questions since they are not applicable for gps checks
+                  .filter((question: any) => question.is_multi_select !== true)
+                  .map((question: any) => ({
+                    value: question.name,
+                    label: question.label,
+                  }))}
                 onChange={(value) => handleFieldChange("grid_id", value)}
               />
             </Col>

--- a/src/modules/DQ/DQChecks/DQCheckGroup1.tsx
+++ b/src/modules/DQ/DQChecks/DQCheckGroup1.tsx
@@ -566,14 +566,22 @@ function DQCheckGroup1({ surveyUID, formUID, typeID }: IDQCheckGroup1Props) {
         if (res?.data?.success) {
           const formDefinition = res.data.data;
           if (formDefinition && formDefinition.questions) {
-            const questionNames = formDefinition.questions.map(
-              (question: any) => ({
-                name: question.question_name,
-                label:
-                  question.question_name +
-                  (question.is_repeat_group ? "_*" : ""),
-              })
+            // Filter to exclude repeat groups with select_multiple question types
+            const filteredQuestions = formDefinition.questions.filter(
+              (question: any) =>
+                !(
+                  question.is_repeat_group &&
+                  question.question_type.startsWith("select_multiple")
+                )
             );
+
+            const questionNames = filteredQuestions.map((question: any) => ({
+              name: question.question_name,
+              label:
+                question.question_name + (question.is_repeat_group ? "_*" : ""),
+              is_multi_select:
+                question.question_type.startsWith("select_multiple"),
+            }));
             setAvailableQuestions(questionNames);
           }
         }

--- a/src/modules/DQ/DQChecks/DQCheckGroup2.tsx
+++ b/src/modules/DQ/DQChecks/DQCheckGroup2.tsx
@@ -427,14 +427,22 @@ function DQCheckGroup2({ surveyUID, formUID, typeID }: IDQCheckGroup1Props) {
         if (res?.data?.success) {
           const formDefinition = res.data.data;
           if (formDefinition && formDefinition.questions) {
-            const questionNames = formDefinition.questions.map(
-              (question: any) => ({
-                name: question.question_name,
-                label:
-                  question.question_name +
-                  (question.is_repeat_group ? "_*" : ""),
-              })
+            // Filter to exclude repeat groups with select_multiple question types
+            const filteredQuestions = formDefinition.questions.filter(
+              (question: any) =>
+                !(
+                  question.is_repeat_group &&
+                  question.question_type.startsWith("select_multiple")
+                )
             );
+
+            const questionNames = filteredQuestions.map((question: any) => ({
+              name: question.question_name,
+              label:
+                question.question_name + (question.is_repeat_group ? "_*" : ""),
+              is_multi_select:
+                question.question_type.startsWith("select_multiple"),
+            }));
             setAvailableQuestions(questionNames);
           }
         }

--- a/src/modules/DQ/DQChecks/DQCheckGroup3.tsx
+++ b/src/modules/DQ/DQChecks/DQCheckGroup3.tsx
@@ -416,14 +416,22 @@ function DQCheckGroup3({ surveyUID, formUID, typeID }: IDQCheckGroup3Props) {
         if (res?.data?.success) {
           const formDefinition = res.data.data;
           if (formDefinition && formDefinition.questions) {
-            const questionNames = formDefinition.questions.map(
-              (question: any) => ({
-                name: question.question_name,
-                label:
-                  question.question_name +
-                  (question.is_repeat_group ? "_*" : ""),
-              })
+            // Filter to exclude repeat groups with select_multiple question types
+            const filteredQuestions = formDefinition.questions.filter(
+              (question: any) =>
+                !(
+                  question.is_repeat_group &&
+                  question.question_type.startsWith("select_multiple")
+                )
             );
+
+            const questionNames = filteredQuestions.map((question: any) => ({
+              name: question.question_name,
+              label:
+                question.question_name + (question.is_repeat_group ? "_*" : ""),
+              is_multi_select:
+                question.question_type.startsWith("select_multiple"),
+            }));
             setAvailableQuestions(questionNames);
           }
         }

--- a/src/modules/DQ/DQChecks/DQCheckGroup4.tsx
+++ b/src/modules/DQ/DQChecks/DQCheckGroup4.tsx
@@ -373,14 +373,21 @@ function DQCheckGroup4({ surveyUID, formUID, typeID }: IDQCheckGroup1Props) {
         if (res?.data?.success) {
           const formDefinition = res.data.data;
           if (formDefinition && formDefinition.questions) {
-            const questionNames = formDefinition.questions.map(
-              (question: any) => ({
-                name: question.question_name,
-                label:
-                  question.question_name +
-                  (question.is_repeat_group ? "_*" : ""),
-              })
+            // Filter to exclude repeat groups with select_multiple question types
+            const filteredQuestions = formDefinition.questions.filter(
+              (question: any) =>
+                !(
+                  question.is_repeat_group &&
+                  question.question_type.startsWith("select_multiple")
+                )
             );
+            const questionNames = filteredQuestions.map((question: any) => ({
+              name: question.question_name,
+              label:
+                question.question_name + (question.is_repeat_group ? "_*" : ""),
+              is_multi_select:
+                question.question_type.startsWith("select_multiple"),
+            }));
             setAvailableQuestions(questionNames);
           }
         }

--- a/src/modules/DQ/DQChecks/DQCheckGroup5.tsx
+++ b/src/modules/DQ/DQChecks/DQCheckGroup5.tsx
@@ -385,14 +385,21 @@ function DQCheckGroup5({ surveyUID, formUID, typeID }: IDQCheckGroup5Props) {
         if (res?.data?.success) {
           const formDefinition = res.data.data;
           if (formDefinition && formDefinition.questions) {
-            const questionNames = formDefinition.questions.map(
-              (question: any) => ({
-                name: question.question_name,
-                label:
-                  question.question_name +
-                  (question.is_repeat_group ? "_*" : ""),
-              })
+            // Filter to exclude repeat groups with select_multiple question types
+            const filteredQuestions = formDefinition.questions.filter(
+              (question: any) =>
+                !(
+                  question.is_repeat_group &&
+                  question.question_type.startsWith("select_multiple")
+                )
             );
+            const questionNames = filteredQuestions.map((question: any) => ({
+              name: question.question_name,
+              label:
+                question.question_name + (question.is_repeat_group ? "_*" : ""),
+              is_multi_select:
+                question.question_type.startsWith("select_multiple"),
+            }));
             setAvailableQuestions(questionNames);
           }
         }

--- a/src/modules/DQ/DQChecks/DQChecksFilter.tsx
+++ b/src/modules/DQ/DQChecks/DQChecksFilter.tsx
@@ -49,6 +49,25 @@ function DQChecksFilter({
           : group
       )
     );
+
+    // if filter operator is changed to "Is empty" or "Is not empty", clear the filter value
+    if (
+      field === "filter_operator" &&
+      (value === "Is empty" || value === "Is not empty")
+    ) {
+      setFilterList((prev: any) =>
+        prev.map((group: any, i: number) =>
+          i === groupIndex
+            ? {
+                ...group,
+                filter_group: group.filter_group.map((filter: any, j: any) =>
+                  j === filterIndex ? { ...filter, filter_value: null } : filter
+                ),
+              }
+            : group
+        )
+      );
+    }
   };
 
   const handleRemoveFilter = (groupIndex: number, filterIndex: number) => {
@@ -182,11 +201,23 @@ function DQChecksFilter({
                         )
                       }
                     >
-                      {validateOperator.map((op: any) => (
-                        <Option key={op} value={op}>
-                          {op}
-                        </Option>
-                      ))}
+                      {
+                        // If the question is select_multiple, we need to show only Contains and Does not contain
+                        filter.question_name &&
+                        questions.find(
+                          (q: any) => q.name === filter.question_name
+                        )?.is_multi_select
+                          ? ["Contains", "Does not contain"].map((op) => (
+                              <Option key={op} value={op}>
+                                {op}
+                              </Option>
+                            ))
+                          : validateOperator.map((op: any) => (
+                              <Option key={op} value={op}>
+                                {op}
+                              </Option>
+                            ))
+                      }
                     </Select>
                   </Col>
                   <Col span={6}>
@@ -214,6 +245,10 @@ function DQChecksFilter({
                         placeholder="Filter value"
                         style={{ width: "100%" }}
                         value={filter.filter_value}
+                        disabled={
+                          filter.filter_operator === "Is empty" ||
+                          filter.filter_operator === "Is not empty"
+                        }
                         onChange={(e: any) =>
                           handleFilterFieldChange(
                             groupIndex,

--- a/src/modules/DQ/DQForm/DQFormManage.tsx
+++ b/src/modules/DQ/DQForm/DQFormManage.tsx
@@ -54,7 +54,7 @@ function DQFormManage() {
     form_name: null,
     tz_name: null,
     scto_server_name: null,
-    encryption_key_shared: null,
+    encryption_key_shared: false,
     server_access_role_granted: null,
     server_access_allowed: null,
     form_type: "dq",


### PR DESCRIPTION
## [SS-2040] - DQ selection on multi-select questions

## Ticket

Fixes: https://idinsight.atlassian.net/browse/SS-2040

## Description, Motivation and Context

This PR adds some checks/constraints on selection on multi-select questions:
1. Don’t allow multi-select with repeat group because it not clear how the output for this looks like. We can add functionality for this if/when this comes up.
2. Don’t allow multi-select in Constraint, Outliers, Protocol Violations, Spotcheck Score and GPS checks because it doesn't make sense to apply these checks on a multi-select variable 
3. In filters, when a multi-select variable is selected, filter operator is restricted to be ‘Contains' or ‘Not contains’.

## How Has This Been Tested?
On local

## UI Changes
None

## To-do before merge
None

## Checklist:

This checklist is a useful reminder of small things that can easily be forgotten.
Put an `x` in all the items that apply and remove any items that are not relevant to this PR.

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- ~~[ ] I have updated the automated tests (if applicable)~~
- [x] I have written [good commit messages][1]
- ~~[ ] I have updated the README file (if applicable)~~
- ~~[ ] I have updated affected documentation (if applicable)~~

[SS-2040]: https://idinsight.atlassian.net/browse/SS-2040?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ