### PR TITLE
[DDSSPB-197] - Updating the row key enumerator uid

### DIFF
--- a/src/modules/Assignments/AssignmentsTab/CreateAssignments/CreateAssignments.tsx
+++ b/src/modules/Assignments/AssignmentsTab/CreateAssignments/CreateAssignments.tsx
@@ -363,10 +363,6 @@ function CreateAssignments() {
     }
   };
 
-  useEffect(() => {
-    console.log("assignmentsResponseData", assignmentResponseData);
-  }, [assignmentResponseData]);
-
   const handleDismiss = (): void => {
     navigate(-1);
   };
@@ -589,7 +585,7 @@ function CreateAssignments() {
                 Select surveyors to assign/re-assign the targets
               </p>
               <Table
-                rowKey={(record: any) => record.email}
+                rowKey={(record: any) => record["enumerator_uid"]}
                 rowSelection={rowSelection}
                 columns={surveyorsTableColumns}
                 dataSource={surveyorsDataSource}


### PR DESCRIPTION
## [DDSSPB-197] - Updating the row key enumerator uid

## Ticket

Fixes: https://idinsight.atlassian.net/browse/DDSSPB-197

## Description, Motivation and Context

The cause of the issue was that the row key for the assignments surveyor table was surveyor email. IFS had uploaded dummy data with duplicates in email. To fix, this PR updates the row key to enumerator uid instead of email. 

## How Has This Been Tested?
On local. Created duplicated emails in enumerators for `test_jt`. Assignments work as expected - https://jam.dev/c/adb98c11-8208-48a3-8322-171b671ab354

## UI Changes
None

## To-do before merge
None

## Checklist:

This checklist is a useful reminder of small things that can easily be forgotten.
Put an `x` in all the items that apply and remove any items that are not relevant to this PR.

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- ~~[ ] I have updated the automated tests (if applicable)~~
- [x] I have written [good commit messages][1]
- ~~[ ] I have updated the README file (if applicable)~~
- ~~[ ] I have updated affected documentation (if applicable)~~

[DDSSPB-197]: https://idinsight.atlassian.net/browse/DDSSPB-197?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ