### PR TITLE
[BUGFIX] Make Assignments screen: Reduce number of warnings and add pagination

### DIFF
--- a/src/modules/Assignments/AssignmentsTab/CreateAssignments/CreateAssignments.tsx
+++ b/src/modules/Assignments/AssignmentsTab/CreateAssignments/CreateAssignments.tsx
@@ -58,7 +58,7 @@ function CreateAssignments() {
   }
 
   // State variables for component
-  const [paginationPageSize, setPaginationPageSize] = useState<number>(25);
+  const [paginationPageSize, setPaginationPageSize] = useState<number>(10);
   const [stepIndex, setStepIndex] = useState<number>(0);
   const [selectedSurveyorRows, setSelectedSurveyorRows] = useState<any>([]);
   const [targetAssignments, setTargetAssignments] = useState<any[]>([]);

--- a/src/modules/Assignments/AssignmentsTab/CreateAssignments/CreateAssignments.tsx
+++ b/src/modules/Assignments/AssignmentsTab/CreateAssignments/CreateAssignments.tsx
@@ -396,6 +396,8 @@ function CreateAssignments() {
     setShowWarnings(false);
     if (selectedAssignmentRows?.length > 0 && selectedSurveyorRows.length > 0) {
       let sIndex = 0;
+      let hasShowedWarning = false;
+
       selectedAssignmentRows.forEach((item: any, index: number) => {
         if (!selectedSurveyorRows[sIndex]) {
           sIndex = 0;
@@ -422,7 +424,11 @@ function CreateAssignments() {
           ) {
             warning =
               "Selected surveyors/targets are either not mapped or are not mapped to the same supervisor";
-            message.warning(warning);
+
+            if (!hasShowedWarning) {
+              message.warning(warning);
+              hasShowedWarning = true;
+            }
             setShowWarnings(true);
           }
 
@@ -655,7 +661,13 @@ function CreateAssignments() {
                     : reviewAssignmentTableColumn
                 }
                 dataSource={targetAssignments}
-                pagination={false}
+                pagination={{
+                  pageSize: paginationPageSize,
+                  pageSizeOptions: [10, 25, 50, 100],
+                  showSizeChanger: true,
+                  showQuickJumper: true,
+                  onShowSizeChange: (_, size) => setPaginationPageSize(size),
+                }}
                 style={{ marginBottom: 20 }}
               />
             </>


### PR DESCRIPTION
## [BUGFIX] Make Assignments screen: Reduce number of warnings and add pagination

## Ticket

Fixes:

## Description, Motivation and Context

Make assignments screen showed a warning if surveyor selected did not have same mapping criteria as target.
The number of warnings shown was equal to the number of targets selected for assignments, which spammed the screen.
Reduced the number of warnings to one per selection.

Review assignments screen: Added pagination to the table for more effortless scrolling of big tables.

Changed default page size to 10 for create assignments table

## How Has This Been Tested?
Local

## UI Changes
<img width="1385" height="853" alt="Screenshot 2025-08-12 at 10 20 36" src="https://github.com/user-attachments/assets/6ba6dc78-6b36-4386-a6ff-2775adddf802" />


## Checklist:

This checklist is a useful reminder of small things that can easily be forgotten.
Put an `x` in all the items that apply and remove any items that are not relevant to this PR.

- [ ] My code follows the style guidelines of this project
- [ ] I have reviewed my own code to ensure good quality
- [ ] I have tested the functionality of my code to ensure it works as intended
- [ ] I have resolved merge conflicts
- [ ] I have updated the automated tests (if applicable)
- [ ] I have written [good commit messages][1]
- [ ] I have updated the README file (if applicable)
- [ ] I have updated affected documentation (if applicable)